### PR TITLE
Packit: Use all available targets in copr

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -16,13 +16,6 @@ jobs:
     owner: rhcontainerbot
     project: packit-builds
     enable_net: true
-    # x86_64 is assumed by default
-    # qm is noarch so we only need to test on one arch
-    targets:
-      - fedora-rawhide
-      - fedora-38
-      - fedora-37
-      - centos-stream-9
     srpm_build_deps:
       - make
       - rpkg


### PR DESCRIPTION
Looks like the `targets` key prevents packit from triggering copr builds on commit to main. This commit removes it so packit will use all available targets on the `rhcontainerbot/packit-builds` copr.

The only additional targets enabled would be aarch64 ones, which shouldn't take longer than the current time for packit builds.