### PR TITLE
Packit: Comment out `trigger: commit` block

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -32,11 +32,14 @@ jobs:
       fix-spec-file:
         - bash .packit.sh
 
-  - <<: *copr
-    # Run on commit to main branch
-    trigger: commit
-    branch: main
-    project: podman-next
+  # FIXME: This section doesn't work as expected yet, so
+  # copr builds to `rhcontainerbot/podman-next` are currently
+  # handled via webhook.
+  #- <<: *copr
+  #  # Run on commit to main branch
+  #  trigger: commit
+  #  branch: main
+  #  project: podman-next
 
   # All tests specified in the `/plans/` subdir
   #- job: tests


### PR DESCRIPTION
This section doesn't work as expected yet, so builds on `rhcontainerbot/podman-next` copr will be triggered using a webhook.