### PR TITLE
Add /dev/kvm device to qm, so VMs can be launched

### DIFF
--- a/qm.container
+++ b/qm.container
@@ -5,13 +5,14 @@ Delegate=true
 IOWeight=50
 ManagedOOMSwap=kill
 MemorySwapMax=0
-Slice=QM.slice
-Restart=always
 # Containers within the qm y default set OOMScoreAdj to 750
 OOMScoreAdjust=500 
+Restart=always
+Slice=QM.slice
 
 [Container]
 AddCapability=all
+AddDevice=/dev/kvm
 ContainerName=qm
 Exec=/sbin/init
 Network=host


### PR DESCRIPTION
In RHIVOS we want to support running VMs and specifically Android within the QM, which requires /dev/kvm to be present.