### PR TITLE
Automatically setup the hirte-agent

### DIFF
--- a/setup
+++ b/setup
@@ -1,4 +1,4 @@
-#! /bin/sh -ex
+#! /bin/sh -e
 #
 # This setup script will install an OS environment by default into
 # /usr/share/qm/rootfs and create a Podman quadlet containerized environment
@@ -9,6 +9,8 @@ if [ "$EUID" -ne 0 ];then
     exit 1
 fi
 
+qmContainerIDs=1000000000:1500000000
+containerIDs=2500000000:1500000000
 replaceIDs() {
     touch $1
     grep -q "^$2:" $1 || echo $2:$3 >> $1
@@ -22,6 +24,27 @@ ROOTFS="$2"
 
 systemctl stop qm.service 2>/dev/null || true
 
+hirteSetup() {
+    rootfs=$1
+    if test ! -f ${rootfs}/etc/hirte/agent.conf; then
+	if test -f /etc/hirte/agent.conf; then
+	    sed -e 's,^NodeName=,NodeName=qm.,g' /etc/hirte/agent.conf >  ${rootfs}/etc/hirte/agent.conf
+	fi
+    fi
+    hostname=$(hostname)
+    if test -f ${rootfs}/etc/hirte/agent.conf; then
+	sed -e "s,^NodeName=qm.$,NodeName=qm.${hostname},g" \
+	    -e "s,^NodeName=$,NodeName=qm.${hostname},g" \
+	    -i ${rootfs}/etc/hirte/agent.conf
+    else
+	cat > ${rootfs}/etc/hirte/agent.conf <<EOF
+[hirte-agent]
+NodeName=qm.${hostname}
+EOF
+    fi
+    chroot ${rootfs} systemctl enable hirte-agent 2> /dev/null
+}
+
 install() {
     rootfs=$1
     . /etc/os-release
@@ -32,16 +55,17 @@ install() {
     cp ${INSTALLDIR}/containers.conf ${rootfs}/etc/containers/
     cp ${INSTALLDIR}/contexts ${rootfs}/usr/share/containers/selinux/
     cp ${INSTALLDIR}/file_contexts ${rootfs}/etc/selinux/targeted/contexts/files/file_contexts
-    replaceIDs ${rootfs}/etc/subuid containers 1000000000:1500000000
-    replaceIDs ${rootfs}/etc/subgid containers 1000000000:1500000000
+    replaceIDs ${rootfs}/etc/subuid containers ${qmContainerIDs}
+    replaceIDs ${rootfs}/etc/subgid containers ${qmContainerIDs}
+    hirteSetup ${rootfs}
     restorecon -R ${rootfs}
 }
 
 install ${ROOTFS}
-replaceIDs /etc/subuid qmcontainers 1000000000:1500000000
-replaceIDs /etc/subgid qmcontainers 1000000000:1500000000
-replaceIDs /etc/subuid containers   2500000000:1500000000
-replaceIDs /etc/subgid containers   2500000000:1500000000
+replaceIDs /etc/subuid qmcontainers ${qmContainerIDs}
+replaceIDs /etc/subgid qmcontainers ${qmContainerIDs}
+replaceIDs /etc/subuid containers   ${containerIDs}
+replaceIDs /etc/subgid containers   ${containerIDs}
 
 systemctl daemon-reload
 systemctl start qm.service


### PR DESCRIPTION
Attempt to first copy the /etc/hirte/agent.conf from the host into the hirte environmnet, and add qm. to the front of the NodeName field.

If the NodeName field does not exists or is emtpy, then add qm.HOSTNAME as the NodeName.

If the NodeName is qm., then add HOSTNAME to the end.