### PR TITLE
quadlet: make `/dev/kvm` optional

### DIFF
--- a/qm.container
+++ b/qm.container
@@ -12,7 +12,7 @@ Slice=QM.slice
 
 [Container]
 AddCapability=all
-AddDevice=/dev/kvm
+AddDevice=-/dev/kvm
 ContainerName=qm
 Exec=/sbin/init
 Network=host


### PR DESCRIPTION
This is required on environments like VMs where /dev/kvm is not present.


@rhatdan @alexlarsson PTAL