### PR TITLE
quadlet: minimal sane default for AllowedCPUs

### DIFF
--- a/qm.container
+++ b/qm.container
@@ -1,5 +1,5 @@
 [Service]
-AllowedCPUs=6-11
+AllowedCPUs=1
 CPUWeight=50
 Delegate=true
 IOWeight=50


### PR DESCRIPTION
Set `AllowedCPUs=` to a minimal sane default which should work for most if not all users.

RPM packaging can optimize this for the env in postinstall.

@rhatdan PTAL