### PR TITLE
Packit: Add downstream Fedora packaging tasks

### DIFF
--- a/.packit.sh
+++ b/.packit.sh
@@ -6,6 +6,9 @@
 
 set -eo pipefail
 
+# Set path to rpm spec file
+SPEC_FILE=rpm/qm.spec
+
 # Get Version from HEAD
 HEAD_VERSION=$(grep '^policy_module' qm.te | sed 's/[^0-9.]//g')
 
@@ -15,13 +18,10 @@ git archive --prefix=qm-$HEAD_VERSION/ -o qm-$HEAD_VERSION.tar.gz HEAD
 # RPM Spec modifications
 
 # Update Version in spec with Version from qm.te
-sed -i "s/^Version:.*/Version: $HEAD_VERSION/" qm.spec
+sed -i "s/^Version:.*/Version: $HEAD_VERSION/" $SPEC_FILE
 
 # Update Release in spec with Packit's release envvar
-sed -i "s/^Release:.*/Release: $PACKIT_RPMSPEC_RELEASE%{?dist}/" qm.spec
+sed -i "s/^Release:.*/Release: $PACKIT_RPMSPEC_RELEASE%{?dist}/" $SPEC_FILE
 
 # Update Source tarball name in spec
-sed -i "s/^Source:.*.tar.gz/Source: %{name}-$HEAD_VERSION.tar.gz/" qm.spec
-
-# Update setup macro to use the correct build dir
-sed -i "s/^%setup.*/%autosetup -Sgit -n %{name}-$HEAD_VERSION/" qm.spec
+sed -i "s/^Source0:.*.tar.gz/Source0: %{name}-$HEAD_VERSION.tar.gz/" $SPEC_FILE

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -5,8 +5,8 @@
 # Build targets can be found at:
 # https://copr.fedorainfracloud.org/coprs/rhcontainerbot/packit-builds/
 
-specfile_path: qm.spec
-
+specfile_path: rpm/qm.spec
+upstream_tag_template: v{version}
 
 jobs:
   - &copr
@@ -21,14 +21,11 @@ jobs:
     targets:
       - fedora-rawhide
       - fedora-38
-      - fedora-37
       - centos-stream-9
     srpm_build_deps:
       - make
       - rpkg
     actions:
-      post-upstream-clone:
-        - rpkg spec --outdir ./
       fix-spec-file:
         - bash .packit.sh
 
@@ -46,10 +43,6 @@ jobs:
       - fedora-38-ppc64le
       - fedora-38-s390x
       - fedora-38-x86_64
-      - fedora-37-aarch64
-      - fedora-37-ppc64le
-      - fedora-37-s390x
-      - fedora-37-x86_64
       - centos-stream+epel-next-9-aarch64
       - centos-stream+epel-next-9-ppc64le
       - centos-stream+epel-next-9-s390x
@@ -61,7 +54,31 @@ jobs:
     branch: main
     project: qm
     targets:
+      - fedora-38-aarch64
+      - fedora-38-ppc64le
+      - fedora-38-x86_64
       - centos-stream-9-aarch64
       - centos-stream-9-ppc64le
-      - centos-stream-9-s390x
       - centos-stream-9-x86_64
+
+  - job: propose_downstream
+    trigger: release
+    update_release: false
+    dist_git_branches:
+      - fedora-rawhide
+      - fedora-38
+      - epel-9
+
+  - job: koji_build
+    trigger: commit
+    dist_git_branches:
+      - fedora-rawhide
+      - fedora-38
+      - epel-9
+
+  - job: bodhi_update
+    trigger: commit
+    dist_git_branches:
+      # rawhide updates are created automatically
+      - fedora-38
+      - epel-9

--- a/rpm/update-spec-version.sh
+++ b/rpm/update-spec-version.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+# This script will update the Version field in the spec which is set to 0 by
+# default. Useful for local manual rpm builds where the Version needs to be set
+# correctly.
+
+SPEC_FILE=$(pwd)/qm.spec
+LATEST_TAG=$(git tag --sort=creatordate | tail -1)
+LATEST_VERSION=$(echo $LATEST_TAG | sed -e 's/^v//')
+
+sed -i "s/^Version:.*/Version: $LATEST_VERSION/" $SPEC_FILE


### PR DESCRIPTION
Get rid of `qm.spec.rpkg` in favour of
`rpm/qm.spec` which gets synced with fedora dist-git on every upstream release. The version in the new spec file is set to `0` by default and gets updated by packit automatically on every packit task.

For local manual rpm builds using the spec, the helper script in the `rpm/` subdir will update the Version field with the latest version found in the upstream repo.

Packit will automatically create a PR on fedora dist-git on every new upstream release. A sample PR will look like:
https://src.fedoraproject.org/rpms/container-selinux/pull-request/10#

A dry run for this can be triggered using:
`$ packit propose-downstream --local-content`

To run this command locally, you would need to have your packit user-configuration-file set.
Ref: https://packit.dev/docs/configuration/#user-configuration-file

along with a fedora api key created at:
https://src.fedoraproject.org/settings#nav-api-tab with sufficient ACLs.