### PR TITLE
Quick doc fix to the setup script

### DIFF
--- a/setup
+++ b/setup
@@ -1,7 +1,7 @@
 #! /bin/sh -e
 #
 # This setup script will install an OS environment by default into
-# /usr/share/qm/rootfs and create a Podman quadlet containerized environment
+# /usr/lib/qm/rootfs and create a Podman quadlet containerized environment
 # running systemd as PID1 inside.
 #
 if [ "$EUID" -ne 0 ];then


### PR DESCRIPTION
The lines documenting what the script does (at the beginning of the script) were pointing to the wrong path/folder being created by this script.

This patch fixes that path to be the correct one