### PR TITLE
No longer need the --nogpgcheck flag

### DIFF
--- a/setup
+++ b/setup
@@ -64,8 +64,8 @@ install() {
     rootfs=$1
     . /etc/os-release
     mkdir -Z -p ${rootfs}
-    dnf -y install --releasever=${VERSION_ID} --installroot ${rootfs} selinux-policy-targeted podman systemd hirte-agent procps-ng --nogpgcheck
-    dnf -y update --installroot ${rootfs} --nogpgcheck
+    dnf -y install --releasever=${VERSION_ID} --installroot ${rootfs} selinux-policy-targeted podman systemd hirte-agent procps-ng
+    dnf -y update --installroot ${rootfs}
     rm -rf ${rootfs}/etc/selinux/targeted/contexts/files/file_contexts/*
     cp ${INSTALLDIR}/containers.conf ${rootfs}/etc/containers/
     cp ${INSTALLDIR}/contexts ${rootfs}/usr/share/containers/selinux/


### PR DESCRIPTION
Seemed to be a temporary bug in fedora 38