### PR TITLE
Update qm /etc/agent/agent.conf that when the qm.service is started

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 The main purpose of this package is allow users to setup an environment which
 prevents applications and container tools from interfering with other all
-other processes on the system.
+other processes on the system. For example ASIL (Automotive Safety Integrity Level)
+environments.
 
 The QM environment uses containerization tools like cgoups, namespaces, and
 security isolation to prevent accidental interference by processes in the qm.
@@ -31,3 +32,20 @@ each other.
 
 For now all of the control processes in the qm other then containers will run
 with the same qm_t type.
+
+* [Hirte](https://github.com/containers/qm/pull/57)
+
+The package configures the hirte agent within the QM.
+
+Hirte is a systemd service controller intended for multi-node environments with
+a predefined number of nodes and with a focus on highly regulated ecosystems such
+as those requiring functional safety. Potential use cases can be found in domains
+such as transportation, where services need to be controlled across different
+edge devices and where traditional orchestration tools are not compliant with
+regulatory requirements.
+
+Systems with QM installed will have two systemd's running on them. The QM hirte-agent
+is based on the hosts /etc/hirte/agent.conf file. By default any changes to the
+systems agent.conf file are reflected into the QM /etc/hirte/agent.conf. You can
+further customize the QM hirte agent by adding content to the
+/usr/lib/qm/rootfs/etc/hirte/agent.conf.d/ directory.

--- a/qm.8.md
+++ b/qm.8.md
@@ -115,5 +115,16 @@ applications within the QM. All applications within the QM environment are
 prevented from interfering with applications running outside of the QM
 environment.
 
+## Configuring hirte agent in the QM
+
+The configuration of the hosts /etc/hirte/agent.conf file is copied into the QM every time the
+qm.service is started, with the nodename of the hosts agent.conf modified by prepending `qm.`
+on the front of the nodename. If the hosts /etc/hirte/agent.conf does not exists, then the
+QM hirte agent will default to `qm.`$(hostname).
+
+If you want permanently modify the hirte agent within the QM you can add config to
+/usr/lib/qm/rootfs/etc/hirte/agent.conf.d/ directory or modify the /etc/containers/systemd/qm.container
+quadlet file to not execute the hirte-agent setup script.
+
 ## SEE ALSO
-**[podman(1)](https://github.com/containers/podman/blob/main/docs/source/markdown/podman.1.md)**, **[quadlet(5)](https://github.com/containers/podman/blob/main/docs/source/markdown/podman-systemd.unit.5.md)**, systemctl(1), systemd(1), dnf(8)
+**[podman(1)](https://github.com/containers/podman/blob/main/docs/source/markdown/podman.1.md)**,**[quadlet(5)](https://github.com/containers/podman/blob/main/docs/source/markdown/podman-systemd.unit.5.md)**, systemctl(1), systemd(1), dnf(8), [hirte-agent(1)](https://github.com/containers/hirte/blob/main/doc/man/hirte-agent.1.md),[hirte-agent.conf.5](https://github.com/containers/hirte/blob/main/doc/man/hirte-agent.conf.5.md)

--- a/qm.container
+++ b/qm.container
@@ -9,6 +9,7 @@ MemorySwapMax=0
 OOMScoreAdjust=500 
 Restart=always
 Slice=QM.slice
+ExecPreStart=/usr/share/qm/setup hirte-agent
 
 [Container]
 AddCapability=all

--- a/setup
+++ b/setup
@@ -16,6 +16,7 @@ replaceIDs() {
     grep -q "^$2:" $1 || echo $2:$3 >> $1
 }
 
+AGENTCONF=/etc/hirte/agent.conf
 INSTALLDIR="$1"
 [ ! -z "${INSTALLDIR}" ] || INSTALLDIR=/usr/share/qm
 
@@ -26,23 +27,22 @@ systemctl stop qm.service 2>/dev/null || true
 
 hirteSetup() {
     rootfs=$1
-    if test ! -f ${rootfs}/etc/hirte/agent.conf; then
-	if test -f /etc/hirte/agent.conf; then
-	    sed -e 's,^NodeName=,NodeName=qm.,g' /etc/hirte/agent.conf >  ${rootfs}/etc/hirte/agent.conf
+    if test ! -f ${rootfs}${AGENTCONF}; then
+	if test -f ${AGENTCONF}; then
+	    sed -e 's,^NodeName=,NodeName=qm.,g' ${AGENTCONF} >  ${rootfs}${AGENTCONF}
 	fi
     fi
     hostname=$(hostname)
-    if test -f ${rootfs}/etc/hirte/agent.conf; then
+    if test -f ${rootfs}${AGENTCONF}; then
 	sed -e "s,^NodeName=qm.$,NodeName=qm.${hostname},g" \
 	    -e "s,^NodeName=$,NodeName=qm.${hostname},g" \
-	    -i ${rootfs}/etc/hirte/agent.conf
+	    -i ${rootfs}${AGENTCONF}
     else
-	cat > ${rootfs}/etc/hirte/agent.conf <<EOF
+	cat > ${rootfs}${AGENTCONF} <<EOF
 [hirte-agent]
 NodeName=qm.${hostname}
 EOF
     fi
-    unshare --mount-proc -R /usr/lib/qm/rootfs -m systemctl enable hirte-agent.service
 }
 
 storage() {
@@ -73,15 +73,23 @@ install() {
     replaceIDs ${rootfs}/etc/subuid containers ${qmContainerIDs}
     replaceIDs ${rootfs}/etc/subgid containers ${qmContainerIDs}
     hirteSetup ${rootfs}
+    unshare --mount-proc -R /usr/lib/qm/rootfs -m systemctl enable hirte-agent.service
     storage ${rootfs}
     restorecon -R ${rootfs}
 }
 
-install ${ROOTFS}
-replaceIDs /etc/subuid qmcontainers ${qmContainerIDs}
-replaceIDs /etc/subgid qmcontainers ${qmContainerIDs}
-replaceIDs /etc/subuid containers   ${containerIDs}
-replaceIDs /etc/subgid containers   ${containerIDs}
-
-systemctl daemon-reload
-systemctl start qm.service
+case "$1" in
+    hirte-agent)
+	rm -f ${ROOTFS}${AGENTCONF}
+	hirteSetup ${ROOTFS}
+	;;
+    *)
+	install ${ROOTFS}
+	replaceIDs /etc/subuid qmcontainers ${qmContainerIDs}
+	replaceIDs /etc/subgid qmcontainers ${qmContainerIDs}
+	replaceIDs /etc/subuid containers   ${containerIDs}
+	replaceIDs /etc/subgid containers   ${containerIDs}
+	systemctl daemon-reload
+	systemctl start qm.service
+	;;
+esac

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -36,10 +36,10 @@ Just call `export VARNAME=foobar` before executing the script.
 | ----------- | ----------- |
 | NUMBER_OF_NODES      | Increase the number of agent nodes. Useful for scale tests.       |
 | NET_INTERFACE_IP_CONTROL   | By default is eth0. Used to collect ip address of controller node        |
-| TAG_CONTROL_MACHINE | The control machine tag. Default is contro:latest
+| TAG_CONTROL_MACHINE | The control machine tag. Default is control:latest
 
 ## Demo
-If your brower doesn't support asciinema, here the demo in text:
+If your browser doesn't support asciinema, here the demo in text:
 ```
 [root@dell730 e2e]# #host
 [root@dell730 e2e]# cat /etc/fedora-release


### PR DESCRIPTION
This pull request will cause the /usr/lib/qm/rootfs/etc/hirte/agent.conf to be created on every qm.service start.  This way if the admin changes the /etc/hirte/agent.conf on the host, the equivalent inside of the qm will match with the exception that the nodename is prefixed with qm.

If the nodename in the hosts /etc/hirte/agent.conf is changed to foobar, then the qm's /etc/hirte/agent.conf will have the same settings except the node name will be qm.foobar.