### PR TITLE
e2e: add initial getopt

### DIFF
--- a/tests/e2e/ContainerFile.control
+++ b/tests/e2e/ContainerFile.control
@@ -45,26 +45,54 @@ RUN dnf -y copr enable rhcontainerbot/qm centos-stream-9
 RUN dnf -y copr enable mperina/hirte-snapshot centos-stream-9
 RUN dnf -y install hirte hirte-agent hirte-ctl
 
+# Script will remove the lines before the commands automatically
+# [manually install hirte] RUN rpm -e hirte hirte-agent hirte-ctl hirte-selinux
+# [manually install hirte] RUN git clone @BUILD_HIRTE_FROM_GH_URL@
+# [manually install hirte] WORKDIR /root/hirte
+
+
+# Look for remote branches
+# [manually install hirte] RUN if git branch -a | grep "remotes/origin/@BRANCH_HIRTE@" &> /dev/null; then \
+# [manually install hirte] git checkout @BRANCH_HIRTE@ &> /dev/null; \
+# [manually install hirte] else \
+# Look to see if the branch already exists, like main branch
+# [manually install hirte] if git branch -a | grep -w @BRANCH_HIRTE@ &> /dev/null; then \
+# [manually install hirte] git checkout @BRANCH_HIRTE@ || true &> /dev/null; \
+# The Branch doesn't exist, create one using -b
+# [manually install hirte] else \
+# [manually install hirte] git checkout -b @BRANCH_HIRTE@ || true &> /dev/null; \
+# [manually install hirte] fi \
+# [manually install hirte] fi
+
+# Execute the build after selecting the branch
+# [manually install hirte] RUN ./build-scripts/build-rpm.sh || true
+
+# Upgrade the current hirte using the new rpm packages but exclude src.rpm
+# [manually install hirte] RUN find . -not -name *.src* -name *.rpm | xargs dnf install -y
+# RUN cp /usr/share/hirte/config/hirte.conf /etc/hirte/hirte.conf.d/hirte.conf
+# [manually install hirte] RUN cp /usr/share/hirte/config/hirte.conf /etc/hirte/hirte.conf
+
 # [start] CONTROL - settings
 # Setting configuration, uncommenting:
 #	- ManagePort to communicate via 842
 #	- Use journal for logging
 #	- Set AllowedNodeNames as control and node1
 # TODO: remove the static node1 here, dynamic by rune2e script via sed
+RUN cp /usr/share/hirte/config/hirte.conf /etc/hirte/
+RUN cp /usr/share/hirte-agent/config/agent.conf /etc/hirte/
 RUN sed -e '/^#ManagerPort=/s/^#//g' \
 	-e '/LogTarget/s/^#//' \
 	-e "s/^AllowedNodeNames=/AllowedNodeNames=control,node1/" \
-	-i /usr/share/hirte/config/hirte.conf
+	-i /etc/hirte/hirte.conf
 # [end] CONTROL - settings
 
 RUN echo 'Foobar!' | passwd --stdin root 
-RUN cp /usr/share/hirte/config/hirte.conf /etc/hirte/hirte.conf.d/hirte.conf
 
 # [start] CONTROL - agent settings
-RUN cp /usr/share/hirte-agent/config/agent.conf /etc/hirte/agent.conf.d/agent.conf
+RUN cp /usr/share/hirte-agent/config/*.conf /etc/hirte/ &> /dev/null
 RUN IPv4_CONTROL="$(ip -brief address show eth0 | awk '{print $3}' | awk -F/ '{print $1}')" && \
 	sed -e "s/NodeName=/NodeName=control/" \
-		-i /etc/hirte/agent.conf.d/agent.conf
+		-i /etc/hirte/agent.conf
 
 # [end] CONTROL - agent settings
 

--- a/tests/e2e/lib/container
+++ b/tests/e2e/lib/container
@@ -94,9 +94,6 @@ create_qm_node() {
             "${IP_CONTROL_MACHINE}"
 
         # Add final instructions
-	echo "RUN dnf -y copr enable rhcontainerbot/qm centos-stream-9 &> /dev/null" >> ContainerFile.node"${nodeID}"
-        echo "RUN dnf -y copr enable mperina/hirte-snapshot centos-stream-9 &> /dev/null" >> ContainerFile.node"${nodeID}"
-        echo "RUN dnf update -y &> /dev/null" >> ContainerFile.node"${nodeID}"
         echo "RUN dnf install qm -y &> /dev/null" >> ContainerFile.node"${nodeID}"
 
 	# Execute qm setup
@@ -107,10 +104,10 @@ create_qm_node() {
 	echo 'RUN echo "AddDevice=-/dev/fuse" >> /usr/share/containers/systemd/qm.container' >> ContainerFile.node"${nodeID}"
 
 	# Enable hirte-agent
-	echo 'RUN cp /usr/share/hirte-agent/config/agent.conf /etc/hirte/agent.conf.d/agent.conf' >> ContainerFile.node"${nodeID}"
+	echo 'RUN cp /usr/share/hirte-agent/config/*.conf /etc/hirte/' >> ContainerFile.node"${nodeID}"
         echo 'RUN sed -i -e "s/NodeName=/NodeName='"node${nodeID}/"\" \
                 '-e "s/^ManagerHost=/ManagerHost='"${IP_CONTROL_MACHINE}/"\" \
-                ' /etc/hirte/agent.conf.d/agent.conf' >> ContainerFile.node"${nodeID}"
+                ' /etc/hirte/agent.conf' >> ContainerFile.node"${nodeID}"
         echo "RUN systemctl enable hirte-agent &> /dev/null" >> ContainerFile.node"${nodeID}"
 
 	# Add systemd as CMD
@@ -141,38 +138,24 @@ create_qm_node() {
 		podman exec qm \
 		cp \
 		/usr/share/hirte-agent/config/agent.conf \
-		/etc/hirte/agent.conf.d/agent.conf
+		/etc/hirte/agent.conf
 	)"
 	if_error_exit "unable to copy agent.conf template to agent.conf.d dir"
 
-	# get the QM nodename from /etc/hirte/agent.conf (env var $NodeName) INSIDE node$ID
-	# FIXME: /etc/hirte/agent.conf should be deprecated soon.
-	qm_node_name=$(podman exec node"${nodeID}" \
-		podman exec qm \
-		cat /etc/hirte/agent.conf | grep NodeName= | awk -F'=' '{print $2}'
-	)
-	if_error_exit "unable to find NodeName in qm container"
-
-	# removing old agent.conf location
-	eval "$(podman exec node"${nodeID}" \
-		podman exec qm \
-		rm -f /etc/hirte/agent.conf
-	)"
-	if_error_exit "unable to remove old agent.conf file"
-
+	qm_node_name="qm-node${nodeID}"
 	NODES_FOR_TESTING+=("${qm_node_name}")
 
 	eval "$(podman exec node"${nodeID}" \
 		podman exec qm \
 		sed -i 's/^ManagerHost=/ManagerHost='"${IP_CONTROL_MACHINE}"'/g' \
-		/etc/hirte/agent.conf.d/agent.conf
+		/etc/hirte/agent.conf
 	)"
 	if_error_exit "qm node: unable to sed ManagerHost in hirte agent.conf"
 
 	eval "$(podman exec node"${nodeID}" \
 		podman exec qm \
 		sed -i 's/^NodeName=/NodeName='"${qm_node_name}"'/g' \
-		/etc/hirte/agent.conf.d/agent.conf
+		/etc/hirte/agent.conf
 	)"
 	if_error_exit "qm node: unable to sed NodeName in hirte agent.conf"
 	
@@ -186,7 +169,7 @@ create_qm_node() {
 	# CONTROL NODE: append QM node into /etc/hirte/agent.conf.din the control node the new qm node name
 	eval "$(podman exec "${CONTROL_CONTAINER_NAME}" \
 		sed -i '/^AllowedNodeNames=/ s/$/,'"${qm_node_name}"'/' \
-		/etc/hirte/hirte.conf.d/hirte.conf
+		/etc/hirte/hirte.conf
 	)"
 	if_error_exit "control node: unable to sed AllowedNodeName in hirte.conf"
 
@@ -201,7 +184,7 @@ create_qm_node() {
 
 create_asil_node() {
     # Creates the control container - a.k.a ASIL
-    info_message "Creating container \033[92m${CONTROL_CONTAINER_NAME}\033[0m [\033[92mASIL mode\033[0m]"
+    info_message "Creating container \033[92m${CONTROL_CONTAINER_NAME}\033[0m [\033[92mASIL mode\033[0m]. It might take some time..."
     create_container \
         "ContainerFile.control" \
         "${CONTROL_CONTAINER_NAME}" \

--- a/tests/e2e/lib/systemd
+++ b/tests/e2e/lib/systemd
@@ -37,7 +37,7 @@ create_stub_systemd_srv() {
         if [ -n "${creates_on_qm_node}" ]; then
             info_message "Creating stub systemd service: \033[92mcontainer-${srv}\033[0m in \033[92m${container_target}\033[0m and moving it to container \033[92mqm\033[0m inside \033[92m${container_target}\033[0m"
 	else
-            info_message "Creating stub systemd service: \033[92mcontainer-${srv}\033[0m in container \033[92m${container_target}\033[0m"
+            info_message "Creating stub systemd service: \033[92mcontainer-${srv}\033[0m in container \033[92m${container_target}\033[0m. It might take some time..."
 	fi
 
         # create stub pod for the service

--- a/tests/e2e/lib/tests
+++ b/tests/e2e/lib/tests
@@ -23,7 +23,8 @@ test_hirte_list_all_units() {
         hirtectl_cmd=$(podman exec \
 		"${CONTROL_CONTAINER_NAME}" \
 		hirtectl \
-		list-units
+		list-units \
+		"${node_name}"
 	)
 	if_error_exit "unable to execute hirtectl command on ${CONTROL_CONTAINER_NAME}"
 	echo "${hirtectl_cmd}" | head -5

--- a/tests/e2e/run-test-e2e
+++ b/tests/e2e/run-test-e2e
@@ -23,12 +23,18 @@ source "${SCRIPT_DIR}"/lib/container
 source "${SCRIPT_DIR}"/lib/systemd
 source "${SCRIPT_DIR}"/lib/tests
 
+# GLOBALS
 export CONFIG_NODE_AGENT_PATH="/etc/hirte/agent.conf.d/agent.conf"
 export REGISTRY_UBI8_MINIMAL="registry.access.redhat.com/ubi8/ubi-minimal"
 export WAIT_HIRTE_SERVER_BE_READY_IN_SEC=5
 export CONTROL_CONTAINER_NAME="control"
 export NODES_FOR_TESTING=("control" "node1")
 export IP_CONTROL_MACHINE=""
+
+export BUILD_QM_FROM_GH_URL=""
+export BUILD_HIRTE_FROM_GH_URL=""
+export BRANCH_HIRTE=""
+export BRANCH_QM=""
 
 # If no additional nodes are required, use 1
 if [ -z "${NUMBER_OF_NODES}" ]; then
@@ -44,9 +50,94 @@ if [ -z "${NET_INTERFACE_IP_CONTROL}" ]; then
 fi
 
 # ====================== Start - int main {} ;-)
+ARGUMENT_LIST=(
+  "build-qm-from-gh-url"
+  "branch-qm"
+  "build-hirte-from-gh-url"
+  "branch-hirte"
+)
+
+usage() {
+	echo "Usage: $0 [OPTIONS]"
+	echo
+	echo "--help"
+        echo -e "\tThis message"
+	echo
+	echo "--build-qm-from-gh-url"
+	echo -e "\tBuild QM from a specific GitHub URL, useful for testing new features"
+	echo "--branch-qm"
+	echo -e "\tSpecify which branch the GitHub repo will be set. Requires --build-qm-from-gh-url"
+	echo
+	echo "--build-hirte-from-gh-url"
+	echo -e "\tBuild HIRTE from a specific GitHub URL, useful for testing new features"
+	echo "--branch-hirte"
+	echo -e "\tSpecify which branch the GitHub repo will be set. Requires --build-hirte-from-gh-url"
+	echo
+	echo "Examples:"
+	echo
+	echo -e "\tNo args, it will install latest qm and hirte from copr rpm repository"
+	echo -e "\t\t${0}"
+	echo
+	echo -e "\tBuild qm and hirte from a specific github url and select the branches"
+	echo -e "\t\t${0} \\"
+	echo -e "\t\t\t--branch-qm=superfeature \\"
+	echo -e	"\t\t\t--build-qm-from-gh-url=https://github.com/MYUSER/qm.git \\"
+	echo -e "\t\t\t--branch-hirte=superfeature"
+	echo -e	"\t\t\t--build-hirte-from-gh-url=https://github.com/MYUSER/hirte.git \\"
+	echo
+	exit 0
+}
+
+# read arguments
+opts=$(getopt \
+  --longoptions "$(printf "help,%s:," "${ARGUMENT_LIST[@]}")" \
+  --name "$(basename "$0")" \
+  --options "" \
+  -- "$@"
+)
+
+eval set --"${opts}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --branch-qm)
+      BRANCH_QM="${2}"
+      shift 2
+      ;;
+
+    --branch-hirte)
+      BRANCH_HIRTE="${2}"
+      shift 2
+
+      ;;
+    --build-qm-from-gh-url)
+      if [ -z "${BRANCH_QM}" ]; then
+          BRANCH_QM="main"
+      fi
+      BUILD_QM_FROM_GH_URL="${2}"
+      shift 2
+      ;;
+
+    --build-hirte-from-gh-url)
+      if [ -z "${BRANCH_HIRTE}" ]; then
+          BRANCH_HIRTE="main"
+      fi
+      BUILD_HIRTE_FROM_GH_URL="${2}"
+      shift 2
+      ;;
+
+    --help)
+      usage
+      shift 2
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
 info_message "Starting setup"
 info_message "=============================="
-
 if [ "$EUID" -ne 0 ]
 then
     echo -e "[\033[91m ERROR\033[0m ] Please run as root this script. It requires to set limits inside a container which is not allowed by root."
@@ -60,6 +151,19 @@ cleanup "node1"
 echo
 info_message "Preparing ASIL environment"
 info_message "=============================="
+
+# If user would like to build hirte from source code, let's adjust the ContainerFile
+if [ -n "${BUILD_HIRTE_FROM_GH_URL}" ]; then
+    echo
+    info_message "Building hirte from source code, using:"
+    info_message "=============================="
+    info_message "\tGH URL: ${BUILD_HIRTE_FROM_GH_URL}"
+    info_message "\tBranch: ${BRANCH_HIRTE}"
+    echo
+    sed -i -e 's#@BUILD_HIRTE_FROM_GH_URL@#'"${BUILD_HIRTE_FROM_GH_URL}"'#g' ContainerFile.control
+    sed -i -e 's/@BRANCH_HIRTE@/'"${BRANCH_HIRTE}"'/g' ContainerFile.control
+    sed -i -e 's/# \[manually install hirte\] //' ContainerFile.control
+fi
 
 # Creates the control container - a.k.a ASIL
 create_asil_node


### PR DESCRIPTION
- Add ability to build hirte from source and selecting branch automatically. Helps to do e2e in different branches and releases.
- Few others improvements and reduced extra work needed.
- Added --build-from-qm source too (needs to be finished.)

