### PR TITLE
Fix handling of /var and /etc within container

### DIFF
--- a/qm.container
+++ b/qm.container
@@ -9,6 +9,7 @@ MemorySwapMax=0
 OOMScoreAdjust=500 
 Restart=always
 Slice=QM.slice
+Environment=ROOTFS=/usr/lib/qm/rootfs
 ExecPreStart=/usr/share/qm/setup hirte-agent
 
 [Container]
@@ -20,9 +21,9 @@ Exec=/sbin/init
 Network=host
 PodmanArgs=--security-opt label=nested --security-opt unmask=all
 ReadOnly=true
-Rootfs=/usr/lib/qm/rootfs
+Rootfs=${ROOTFS}
 SecurityLabelFileType=qm_file_t
 SecurityLabelLevel=s0
 SecurityLabelType=qm_t
-Volume=qmEtc:/etc:copy
-Volume=qmVar:/var:copy
+Volume=${ROOTFS}/etc:/etc
+Volume=${ROOTFS}/var:/var


### PR DESCRIPTION
With the current code using builtin volumes users on the host system can not modify the ROOTFS/var and ROOTFS/etc directories.
This PR just remounts these directories on top of themselves read/write allowing users from the host to modify the directories and the processes inside of the container to modify them.
Both the host and the QM will be able to see the modifications.

Added a ROOTFS=/usr/lib/qm/rootfs environment variable to make the quadlet easier to understand.