### PR TITLE
Packit: Temporarily disable bodhi for epel9

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -81,4 +81,6 @@ jobs:
     dist_git_branches:
       # rawhide updates are created automatically
       - fedora-38
-      - epel-9
+      # Disable bodhi for epel-9 until hirte and podman 4.5 are available
+      # Ref: https://bodhi.fedoraproject.org/updates/FEDORA-EPEL-2023-77d64cf134#comment-3026157
+      #- epel-9

--- a/rpm/qm.spec
+++ b/rpm/qm.spec
@@ -12,10 +12,12 @@
 # Format must contain '$x' somewhere to do anything useful
 %global _format() export %1=""; for x in %{modulenames}; do %1+=%2; %%1+=" "; done;
 
-%if 0%{?fedora}
-%global podman_epoch 5
+%if 0%{?rhel}
+%bcond_with podman_45
+%bcond_with hirte_agent
 %else
-%global podman_epoch 2
+%bcond_without podman_45
+%bcond_without hirte_agent
 %endif
 
 Name: qm
@@ -41,8 +43,12 @@ Requires(post): selinux-policy-base >= %_selinux_policy_version
 Requires(post): selinux-policy-targeted >= %_selinux_policy_version
 Requires(post): policycoreutils
 Requires(post): libselinux-utils
-Requires: podman >= %{podman_epoch}:4.5
+%if %{with podman_45}
+Requires: podman >= 5:4.5
+%endif
+%if %{with hirte_agent}
 Requires: hirte-agent
+%endif
 
 %description
 This package allow users to setup an environment which prevents applications


### PR DESCRIPTION
Podman v4.5 and hirte-agent are not yet available on epel9 so this commit removes those dependencies for epel9 and leaves it to the user to fetch those.

Bodhi updates are also disabled so the built package never gets submitted to any yum repo.

Refs:
1. https://bodhi.fedoraproject.org/updates/FEDORA-EPEL-2023-77d64cf134#comment-3026157
2. https://github.com/containers/qm/pull/59#issuecomment-1551691316