### PR TITLE
Updating images iptables-services

### DIFF
--- a/tests/e2e/ContainerFile.control
+++ b/tests/e2e/ContainerFile.control
@@ -5,6 +5,7 @@ RUN dnf install -y \
 	epel-release
 
 RUN dnf config-manager -y --set-enabled crb
+RUN dnf -y copr enable rhcontainerbot/qm centos-stream-9
 
 RUN dnf install -y \
 	clang-tools-extra \
@@ -14,6 +15,7 @@ RUN dnf install -y \
         meson \
 	hostname \
 	podman \
+        iptables-services \
         selinux-policy-targeted \
         selinux-policy-devel \
 	systemd \
@@ -41,7 +43,6 @@ RUN dnf install -y \
 
 WORKDIR /root
 
-RUN dnf -y copr enable rhcontainerbot/qm centos-stream-9
 RUN dnf -y copr enable mperina/hirte-snapshot centos-stream-9
 RUN dnf -y install hirte hirte-agent hirte-ctl
 

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -16,6 +16,9 @@ Demo:
 ## Requirements
 A recent version of Fedora or CentOS9 with the following packages: bash, selinux and podman. 
 Make sure to enable `cgroupv2`.
+Enable the following on host machine before installing podman
+[hirte_repo](https://github.com/containers/qm/blob/main/tests/e2e/ContainerFile.control#L44-L45)
+
 
 ## Tests executed
 The idea behind the test is: create isolated environments using technologies like containers, podman (quadlet), selinux and cgroupv2. On top of that, make sure all systemd services in the nodes are controlled remotely taking advanced of [hirte](https://github.com/containers/hirte/).


### PR DESCRIPTION
e2e tests failed consistently on CentosStream9 with errors Error: netavark: code: 3, msg: modprobe: FATAL: Module ip ptables v1.8.8 (legacy): can't initialize iptables table

Updating Readme/requirements to consume latest:
podman
hirte