### PR TITLE
Make %ghost own the file created in %post

### DIFF
--- a/rpm/qm.spec
+++ b/rpm/qm.spec
@@ -125,7 +125,7 @@ fi
 %ghost %dir %{_datadir}/containers
 %ghost %dir %{_datadir}/containers/systemd
 %{_datadir}/containers/systemd/qm.container
-%ghost %{_sysconfdir}/systemd/qm.container
+%ghost %{_sysconfdir}/containers/systemd/qm.container
 %{_mandir}/man8/*
 %ghost %dir %{_installscriptdir}
 %ghost %dir %{_installscriptdir}/rootfs


### PR DESCRIPTION
Otherwise we end up with a file in /etc/containers/systemd that isn't linked in the RPM database to the qm package making people wonder where this is coming from.