### PR TITLE
Fix #101

### DIFF
--- a/qm.container
+++ b/qm.container
@@ -10,7 +10,7 @@ OOMScoreAdjust=500
 Restart=always
 Slice=QM.slice
 Environment=ROOTFS=/usr/lib/qm/rootfs
-ExecPreStart=/usr/share/qm/setup hirte-agent
+ExecStartPre=/usr/share/qm/setup hirte-agent
 
 [Container]
 AddCapability=all


### PR DESCRIPTION
Fixed a typo in `qm.container` causing systemd to report `Unknown key name 'ExecPreStart' in section 'Service', ignoring`.

Fixes #101