### PR TITLE
start qm.service at boot

### DIFF
--- a/qm.container
+++ b/qm.container
@@ -1,3 +1,6 @@
+[Install]
+WantedBy=default.target
+
 [Service]
 AllowedCPUs=1
 CPUWeight=50


### PR DESCRIPTION
Added Install section as per
https://docs.podman.io/en/latest/markdown/podman-systemd.unit.5.html in order to get the container up after reboot.

Fixes #105