### PR TITLE
stop qm.service only on real install

### DIFF
--- a/setup
+++ b/setup
@@ -83,7 +83,9 @@ case "$1" in
 	hirteSetup "${ROOTFS}"
 	;;
     *)
-	systemctl stop qm.service 2>/dev/null || true
+	if systemctl is-active --quiet "qm.service" ; then
+		systemctl stop qm.service
+	fi
 	install "${ROOTFS}"
 	replaceIDs /etc/subuid qmcontainers ${qmContainerIDs}
 	replaceIDs /etc/subgid qmcontainers ${qmContainerIDs}

--- a/setup
+++ b/setup
@@ -23,8 +23,6 @@ INSTALLDIR="$1"
 ROOTFS="$2"
 [ -n "${ROOTFS}" ] || ROOTFS=/usr/lib/qm/rootfs
 
-systemctl stop qm.service 2>/dev/null || true
-
 hirteSetup() {
     ROOTFS=$1
     if test ! -f "${ROOTFS}${AGENTCONF}"; then
@@ -85,6 +83,7 @@ case "$1" in
 	hirteSetup "${ROOTFS}"
 	;;
     *)
+	systemctl stop qm.service 2>/dev/null || true
 	install "${ROOTFS}"
 	replaceIDs /etc/subuid qmcontainers ${qmContainerIDs}
 	replaceIDs /etc/subgid qmcontainers ${qmContainerIDs}


### PR DESCRIPTION
previously qm.service was stopped always, including when reconfiguring hirte-agent at qm.service start.

Now qm.service is stopped only if a real install is being executed.

Fixes #106