### PR TITLE
spec: require golang-github-cpuguy83-md2man

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,13 @@ is based on the hosts /etc/hirte/agent.conf file. By default any changes to the
 systems agent.conf file are reflected into the QM /etc/hirte/agent.conf. You can
 further customize the QM hirte agent by adding content to the
 /usr/lib/qm/rootfs/etc/hirte/agent.conf.d/ directory.
+
+## RPM building dependencies
+
+In order to build qm package on CentOS Stream 9 you'll need Code Ready Builder
+repository enabled in order to provide `golang-github-cpuguy83-md2man` package.
+
+```console
+# dnf install -y python3-dnf-plugins-core
+# dnf config-manager --set-enabled crb
+```

--- a/rpm/qm.spec
+++ b/rpm/qm.spec
@@ -47,7 +47,8 @@ URL: https://github.com/containers/qm
 Summary: Containerized environment for running Quality Management software
 Source0: %{url}/archive/v%{version}.tar.gz
 BuildArch: noarch
-BuildRequires: %{_bindir}/go-md2man
+# golang-github-cpuguy83-md2man on CentOS Stream 9 is available in CRB repository
+BuildRequires: golang-github-cpuguy83-md2man
 BuildRequires: container-selinux
 BuildRequires: make
 BuildRequires: git-core


### PR DESCRIPTION
explicitly require `golang-github-cpuguy83-md2man` instead of `%{_bindir}/go-md2man` and added a note about where to find it on CentOS Stream 9.

Fixes #120