### PR TITLE
e2e: remove commented line in the AllowedNodeNames

### DIFF
--- a/tests/e2e/lib/container
+++ b/tests/e2e/lib/container
@@ -169,7 +169,7 @@ create_qm_node() {
 
 	# CONTROL NODE: append QM node into /etc/hirte/agent.conf.din the control node the new qm node name
 	eval "$(podman exec "${CONTROL_CONTAINER_NAME}" \
-		sed -i '/^#AllowedNodeNames=/ s/$/,'"${qm_node_name}"'/' \
+		sed -i '/^AllowedNodeNames=/ s/$/,'"${qm_node_name}"'/' \
 		/etc/hirte/hirte.conf
 	)"
 	if_error_exit "control node: unable to sed AllowedNodeName in hirte.conf"


### PR DESCRIPTION
In this moment of the deploy, this option is not commented. Fixing the sed.