### PR TITLE
e2e: run-test-e2e add --number-of-nodes

### DIFF
--- a/tests/e2e/run-test-e2e
+++ b/tests/e2e/run-test-e2e
@@ -56,6 +56,7 @@ ARGUMENT_LIST=(
   "build-hirte-from-gh-url"
   "branch-hirte"
   "skip-tests"
+  "number-of-nodes"
 )
 
 usage() {
@@ -68,6 +69,9 @@ usage() {
 	echo -e "\tBuild QM from a specific GitHub URL, useful for testing new features"
 	echo "--branch-qm"
 	echo -e "\tSpecify which branch the GitHub repo will be set. Requires --build-qm-from-gh-url"
+	echo
+	echo "--number-of-nodes"
+	echo -e "\tSpecify number of nodes. (default 1)"
 	echo
 	echo "--build-hirte-from-gh-url"
 	echo -e "\tBuild HIRTE from a specific GitHub URL, useful for testing new features"
@@ -131,6 +135,15 @@ while [[ $# -gt 0 ]]; do
 
     --skip-tests)
       SKIP_TESTS="${2}"
+      shift 2
+      ;;
+
+    --number-of-nodes)
+      NUMBER_OF_NODES="${2}"
+
+      # avoid "too many files opened"
+      sysctl fs.inotify.max_user_instances=$((${2}*100))
+
       shift 2
       ;;
 


### PR DESCRIPTION
To test hirte and qm in scale we will need a way to easily create 'N' nodes.

Example for creating 8 nodes with 8 qm containers inside:
   ./run-test-e2e --number-of-node=8