### PR TITLE
e2e: ignore some outputs

### DIFF
--- a/tests/e2e/run-test-e2e
+++ b/tests/e2e/run-test-e2e
@@ -142,7 +142,7 @@ while [[ $# -gt 0 ]]; do
       NUMBER_OF_NODES="${2}"
 
       # avoid "too many files opened"
-      sysctl fs.inotify.max_user_instances=$((${2}*100))
+      sysctl fs.inotify.max_user_instances=$((${2}*100)) 1> /dev/null
 
       shift 2
       ;;
@@ -167,7 +167,7 @@ fi
 info_message "Creating dual stack network"
 podman network \
     create --ipv6 --gateway fd00::1:8:1 --subnet fd00::1:8:0/112 \
-    --gateway 10.90.0.1 --subnet 10.90.0.0/16 podmanDualStack
+    --gateway 10.90.0.1 --subnet 10.90.0.0/16 podmanDualStack &> /dev/null
 
 info_message "Cleaning any previous e2e files"
 cleanup "${CONTROL_CONTAINER_NAME}"


### PR DESCRIPTION
- the network creation can show an error like "network already exists"
- sysctl stdin output can be ignored as well