### PR TITLE
e2e: add tool remove-containers.sh

### DIFF
--- a/tests/e2e/tools/README.md
+++ b/tests/e2e/tools/README.md
@@ -1,0 +1,1 @@
+The `remove-containers` script will remove all containers (and images) which name start with node* or control from the output of podman ps. Useful to cleanup environment before executing tests and measures.

--- a/tests/e2e/tools/remove-containers
+++ b/tests/e2e/tools/remove-containers
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+output=$(podman ps -a --format "{{.Names}}")
+IFS=$'\n' # Set the internal field separator to newline
+
+# DO NOT use double quotes here
+for node in ${output}; do
+    if [[ "${node}" == "control" ]] || [[ "${node}" =~ ^node.* ]]; then
+	echo "Removing container ${node}..."
+        podman rm --storage --force "${node}" &> /dev/null
+        podman rm "${node}" --force 1> /dev/null
+    fi
+done


### PR DESCRIPTION
remove all containers/image which name start with node* or control from the output of podman ps.
Useful to cleanup environments before measures.

Signed-off-by: Douglas Schilling Landgraf <dougsland@redhat.com>