### PR TITLE
partially revert commit 1cfd978

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -89,7 +89,7 @@ jobs:
     dist_git_branches:
       # rawhide updates are created automatically
       - fedora-38
-      # Disable bodhi for epel-9 until hirte and podman 4.5 are available
+      # Disable bodhi for epel-9 until hirte and podman 4.5 are available in RHEL 9.
+      # Please note it's already available in CentOS Stream.
       # Ref: https://bodhi.fedoraproject.org/updates/FEDORA-EPEL-2023-77d64cf134#comment-3026157
       #- epel-9
-

--- a/rpm/qm.spec
+++ b/rpm/qm.spec
@@ -20,12 +20,20 @@
 %bcond_without copr
 %endif
 
-%if 0%{?rhel}
+
+
+%if 0%{?fedora}
+%global podman_epoch 5
+%else
+%global podman_epoch 2
+%endif
+
+%if 0%{?rhel} && 0%{?centos} == 0
+# podman 4.5 is not available in RHEL 9 but it's available in CentOS Stream 9.
+# hirte-agent is available in EPEL 9.
 %bcond_with podman_45
-%bcond_with hirte_agent
 %else
 %bcond_without podman_45
-%bcond_without hirte_agent
 %endif
 
 Name: qm
@@ -61,11 +69,9 @@ Requires(post): selinux-policy-targeted >= %_selinux_policy_version
 Requires(post): policycoreutils
 Requires(post): libselinux-utils
 %if %{with podman_45}
-Requires: podman >= 5:4.5
+Requires: podman >= %{podman_epoch}:4.5
 %endif
-%if %{with hirte_agent}
 Requires: hirte-agent
-%endif
 
 %description
 This package allow users to setup an environment which prevents applications


### PR DESCRIPTION
This reverts commit 1cfd9786d41edd0f9d91bc433799c9460bfded3e.
Now podman 4.6 is included in CentOS Stream 9

Fixes #146