### PR TITLE
packit: Build PRs into default packit COPRs

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -2,43 +2,36 @@
 # See the documentation for more information:
 # https://packit.dev/docs/configuration/
 
-# Build targets can be found at:
-# https://copr.fedorainfracloud.org/coprs/rhcontainerbot/packit-builds/
-
 specfile_path: rpm/qm.spec
 upstream_tag_template: v{version}
 
+srpm_build_deps:
+  - make
+  - rpkg
+
+actions:
+  fix-spec-file:
+    - bash .packit.sh
+
 jobs:
-  - &copr
-    job: copr_build
-    # Run on every PR
+  - job: copr_build
     trigger: pull_request
-    owner: rhcontainerbot
-    project: packit-builds
-    enable_net: true
     # x86_64 is assumed by default
     # qm is noarch so we only need to test on one arch
     targets:
       - fedora-rawhide
-      - fedora-38
+      - fedora-latest
       - centos-stream-9
-    srpm_build_deps:
-      - make
-      - rpkg
-    actions:
-      fix-spec-file:
-        - bash .packit.sh
 
-  - <<: *copr
-    # Run on commit to main branch
+  # Run on commit to main branch
+  - &copr
+    job: copr_build
     trigger: commit
     branch: main
+    owner: rhcontainerbot
     project: podman-next
 
   - <<: *copr
-    # Run on commit to main branch
-    trigger: commit
-    branch: main
     project: qm
 
   - job: tests

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -34,32 +34,12 @@ jobs:
     trigger: commit
     branch: main
     project: podman-next
-    targets:
-      - fedora-rawhide-aarch64
-      - fedora-rawhide-ppc64le
-      - fedora-rawhide-s390x
-      - fedora-rawhide-x86_64
-      - fedora-38-aarch64
-      - fedora-38-ppc64le
-      - fedora-38-s390x
-      - fedora-38-x86_64
-      - centos-stream+epel-next-9-aarch64
-      - centos-stream+epel-next-9-ppc64le
-      - centos-stream+epel-next-9-s390x
-      - centos-stream+epel-next-9-x86_64
 
   - <<: *copr
     # Run on commit to main branch
     trigger: commit
     branch: main
     project: qm
-    targets:
-      - fedora-38-aarch64
-      - fedora-38-ppc64le
-      - fedora-38-x86_64
-      - centos-stream-9-aarch64
-      - centos-stream-9-ppc64le
-      - centos-stream-9-x86_64
 
   - job: tests
     trigger: pull_request
@@ -92,4 +72,3 @@ jobs:
       # Disable bodhi for epel-9 until hirte and podman 4.5 are available
       # Ref: https://bodhi.fedoraproject.org/updates/FEDORA-EPEL-2023-77d64cf134#comment-3026157
       #- epel-9
-


### PR DESCRIPTION
Building all PRs of all container projects into the same COPR does not
properly isolate PRs from each other.

To avoid that, change the copr_build configuration to use the packit
default COPRs, which are specific to the particular PR, and disappear
after a few weeks. Depending projects should only run against what
landed in qm/main i.e. the podman-next COPR.

Signed-off-by: Martin Pitt <mpitt@redhat.com>

----

This is exactly the same as https://github.com/containers/crun/pull/1260 ; please see the discussion there, this change needs to be applied to all container projects, and then all land together. Let's keep all the relevant discussions and tracking in  the crun PR please.