### PR TITLE
packit: Restore podman-next target list

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -30,9 +30,29 @@ jobs:
     branch: main
     owner: rhcontainerbot
     project: podman-next
+    targets:
+      - fedora-rawhide-aarch64
+      - fedora-rawhide-ppc64le
+      - fedora-rawhide-s390x
+      - fedora-rawhide-x86_64
+      - fedora-38-aarch64
+      - fedora-38-ppc64le
+      - fedora-38-s390x
+      - fedora-38-x86_64
+      - centos-stream+epel-next-9-aarch64
+      - centos-stream+epel-next-9-ppc64le
+      - centos-stream+epel-next-9-s390x
+      - centos-stream+epel-next-9-x86_64
 
   - <<: *copr
     project: qm
+    targets:
+      - fedora-38-aarch64
+      - fedora-38-ppc64le
+      - fedora-38-x86_64
+      - centos-stream-9-aarch64
+      - centos-stream-9-ppc64le
+      - centos-stream-9-x86_64
 
   - job: tests
     trigger: pull_request


### PR DESCRIPTION
I removed them in commit 62c1ee9f17 with ignoring that this is a deliberate subset of targets, as this project doesn't build in e.g. Fedora 37 or C8S. Put them back.

-----

I was checking [recent podman-next builds](https://copr.fedorainfracloud.org/coprs/rhcontainerbot/podman-next/builds/) after the landed packit PRs today, and noticed the [build failures](https://copr.fedorainfracloud.org/coprs/rhcontainerbot/podman-next/build/6257432/). Sorry for the blunder!

[This is the net diff](https://github.com/containers/qm/compare/a44f687e4285949e270137f00e8dc07d22975678..0cace9f6b9bd780c7e35de684d4ba62102cd4232#diff-2b4300f6d69654fd71c0cdd329b5a5f13fa8fe7eb709c76276bdfd3ea1dde578) of packit.yaml between  before PR #160 and this (ignore the tests/e2e bits, that PR landed in between)

@lsm5 