### PR TITLE
e2e: add more packages as requirement

### DIFF
--- a/tests/e2e/lib/ContainerFile.template
+++ b/tests/e2e/lib/ContainerFile.template
@@ -12,6 +12,9 @@ RUN dnf install -y \
         codespell \
         bzip2 \
         gcc \
+	g++ \
+	fpaste \
+	lcov \
         meson \
 	hostname \
 	podman \


### PR DESCRIPTION
lcov - required for bluechi for doc generation
g++ - required for bluechi
fpaste - easy to share logs

Signed-off-by: Douglas Schilling Landgraf <dougsland@redhat.com>