### PR TITLE
e2e: add go-toolset

### DIFF
--- a/tests/e2e/lib/ContainerFile.template
+++ b/tests/e2e/lib/ContainerFile.template
@@ -15,6 +15,7 @@ RUN dnf install -y \
 	gcc \
 	g++ \
 	gh \
+	go-toolset \
 	fpaste \
 	lcov \
 	hostname \


### PR DESCRIPTION
go-toolset provides the Go programming language tools and libraries.

Fixes: https://github.com/containers/qm/issues/191

Signed-off-by: Douglas Schilling Landgraf <dougsland@redhat.com>