### PR TITLE
build: adjust make to handle floats in os-release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,9 +24,8 @@ selinux: qm.pp
 
 %.pp: %.te
 	mkdir -p tmp; cp qm.* tmp/
-	@source /etc/os-release && \
-	if [ "$$VERSION_ID" -le 9 ] && ( echo "$$ID" | tr '[:upper:]' '[:lower:]' | uniq -u | grep -q -i -E "(centos|rhel|autosd)" ); then \
-                sed -i /user_namespace/d tmp/qm.if; \
+	@if ./build-aux/validations ; then \
+		sed -i /user_namespace/d tmp/qm.if; \
 	fi
 	make -C tmp -f ${DATADIR}/selinux/devel/Makefile $@
 	cp tmp/qm.pp .; rm -rf tmp

--- a/build-aux/validations
+++ b/build-aux/validations
@@ -1,0 +1,12 @@
+#!/bin/bash
+source /etc/os-release
+
+versionid=$(echo $VERSION_ID | awk -F. '{print $1}')
+id_os=$(echo $ID | grep -i -E "(centos|rhel|autosd)")
+
+if [ "${versionid}" -le 9 ] && [ -n ${id_os} ] ; then
+    # the sed command is required for the selinux
+    exit 0
+fi
+
+exit 1


### PR DESCRIPTION
The script was failing when getting "9.2" in VERSION_ID.

Signed-off-by: Douglas Schilling Landgraf <dougsland@redhat.com>