### PR TITLE
e2e: Add dbus-devel package

### DIFF
--- a/tests/e2e/lib/ContainerFile.template
+++ b/tests/e2e/lib/ContainerFile.template
@@ -15,6 +15,7 @@ RUN dnf install -y \
 	cargo \
 	rust \
 	gcc \
+	dbus-devel \ 
 	g++ \
 	gh \
 	go-toolset \


### PR DESCRIPTION
dbus-devel provides libraries and header files needed for developing software that uses D-BUS.

Signed-off-by: Douglas Schilling Landgraf <dougsland@redhat.com>