### PR TITLE
Fix setup of bluechi-agent.service

### DIFF
--- a/setup
+++ b/setup
@@ -105,9 +105,9 @@ install() {
     if [ "$SYSTEMCTL_SKIP" == "N" ]; then
         unshare --mount-proc -R "${ROOTFS}" -m systemctl enable bluechi-agent.service
     else
-        ln -s \
-            ${ROOTFS}/usr/lib/systemd/system/bluechi-agent.service \
-            ${ROOTFS}/etc/systemd/system/multi-user.target.wants/bluechi-agent.service
+        chroot ${ROOTFS} ln -fs \
+            /usr/lib/systemd/system/bluechi-agent.service \
+            /etc/systemd/system/multi-user.target.wants/bluechi-agent.service
     fi
 
     storage "${ROOTFS}"


### PR DESCRIPTION
Currently the bluechi-agent.service is not enabled inside of the qm, when run with $SYSTEMCTL_SKIP=y

The $ROOTFS is leaking into the link.