### PR TITLE
[WIP] limit the number of processes inside of the QM

### DIFF
--- a/qm.container
+++ b/qm.container
@@ -21,6 +21,7 @@ AddDevice=-/dev/fuse
 ContainerName=qm
 Exec=/sbin/init
 Network=host
+PidsLimit=10000
 PodmanArgs=--security-opt label=nested --security-opt unmask=all
 ReadOnly=true
 Rootfs=${ROOTFS}


### PR DESCRIPTION
The default limit on number of processes within the container is 1024. This is far too low for QM. Selecting 10000 seems like a better number but really this needs to be set by the final distributor of the OS.

Requires https://github.com/containers/podman/pull/19955 to be in Podman.