### PR TITLE
limit the number of processes/tasks inside of the QM

### DIFF
--- a/qm.container
+++ b/qm.container
@@ -13,15 +13,18 @@ OOMScoreAdjust=500
 Restart=always
 Slice=QM.slice
 Environment=ROOTFS=/usr/lib/qm/rootfs
+LimitNOFILE=65536
+TasksMax=50%
 
 [Container]
 AddCapability=all
+DropCapability=sys_resource
 AddDevice=-/dev/kvm
 AddDevice=-/dev/fuse
 ContainerName=qm
 Exec=/sbin/init
 Network=host
-PodmanArgs=--security-opt label=nested --security-opt unmask=all
+PodmanArgs=--pids-limit=-1 --security-opt label=nested --security-opt unmask=all
 ReadOnly=true
 Rootfs=${ROOTFS}
 SecurityLabelFileType=qm_file_t


### PR DESCRIPTION
The default limit on number of processes within the container is 2048. This is far too low for QM. Selecting 50% of max seems like a better number but really this needs to be set by the final distributor of the OS.

Also set the maximum number of open file descriptors.