### PR TITLE
Updating tests to work against qm AutoSD image

### DIFF
--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -141,6 +141,7 @@ Refer [FMF](https://fmf.readthedocs.io/en/stable) for tmt test metadata specific
 ### Run TMT tests framework locally
 
 #### Setup device under test
+
 - Install required packages
 
 ``` bash
@@ -169,7 +170,8 @@ virt-customize -a /tmp/CentOS-Stream-GenericCloud-9-latest.x86_64.qcow2 --root-p
 
 ``` bash
 /usr/bin/qemu-system-x86_64 -nographic -smp 12 -enable-kvm -m 2G -machine q35 -cpu host -device virtio-net-pci,netdev=n0,mac=FE:30:26:a6:91:2d -netdev user,id=n0,net=10.0.2.0/24,hostfwd=tcp::2222-:22 -drive file=/tmp/CentOS-Stream-GenericCloud-9-latest.x86_64.qcow2,index=0,media=disk,format=qcow2,if=virtio,snapshot=off
-``` 
+```
+
 **To exit from qemu**: `CTRL-a c` and then `quit` into the qemu terminal
 
 #### Install TMT locally (python)
@@ -201,5 +203,24 @@ tmt run plans -n tests/e2e/tier-0
 
 or connecting to VM:
 
-tmt run -a provision --how connect -u root -p ${PASSWORD} -P 2222 -g localhost plans -n /tests/e2e/tier-0
+tmt run -c distro=centos-stream-9 -a \
+        provision --how connect -u root -p ${PASSWORD} -P ${PORT} -g localhost \
+        plans -n /tests/e2e/tier-0
+```
+
+##### Other tmt configurations
+
+In case of running against prepared image, such as AutoSD, use the following tmt comman
+Where there is already running:
+
+- qm container with bluechi agent running under systemd.
+
+- host is running bluechi and bluechi agent.
+
+Override the context distro and CONTROL_CONTAINER_NAME and NODES_FOR_TESTING_ARR
+
+``` bash
+tmt  -c distro=automotive-stream-distribution-9 run -e CONTROL_CONTAINER_NAME="host" \
+     -e NODES_FOR_TESTING_ARR="\"host qm.host\""  -a \
+     provision --how connect -u root -p ${PASSWORD} -P {PORT} -g localhost plans -n /tests/e2e/tier-0
 ```

--- a/tests/e2e/lib/tests
+++ b/tests/e2e/lib/tests
@@ -21,7 +21,6 @@
 NODES_FOR_TESTING_ARR="${NODES_FOR_TESTING_ARR:-control qm-node1}"
 readarray -d ' ' -t NODES_FOR_TESTING <<< "$NODES_FOR_TESTING_ARR"
 
-CONTROL_CONTAINER_CMD=${CONTROL_CONTAINER_CMD:-podman exec}
 CONTROL_CONTAINER_NAME="${CONTROL_CONTAINER_NAME:-control}"
 
 test_bluechi_list_all_units() {
@@ -29,13 +28,25 @@ test_bluechi_list_all_units() {
     do
         echo
         info_message "Connected to \033[92m${CONTROL_CONTAINER_NAME}\033[0m, listing few systemd units from \033[92m${node_name}\033[0m"
-        bluechictl_cmd=$(eval "${CONTROL_CONTAINER_CMD} \
-                ${CONTROL_CONTAINER_NAME} \
-                bluechictl \
-                list-units \
-                ${node_name}"
-        )
+        if [ "${CONTROL_CONTAINER_NAME}" = "host" ]; then
+           bluechictl_cmd=$(eval "bluechictl \
+                   list-units \
+                   ${node_name}"
+           )
+        else
+           bluechictl_cmd=$(eval "podman exec \
+                   ${CONTROL_CONTAINER_NAME} \
+                   bluechictl \
+                   list-units \
+                   ${node_name}"
+           )
+        fi
         if_error_exit "unable to execute bluechictl command on ${CONTROL_CONTAINER_NAME}"
-        grep -E  "container-|qm.service" <<< ${bluechictl_cmd}
+
+        if [ "${CONTROL_CONTAINER_NAME}" = "host" ]; then
+           grep -E  "bluechi|qm" <<< ${bluechictl_cmd}
+        else
+           grep -E  "container-|qm.service" <<< ${bluechictl_cmd}
+        fi
     done
 }

--- a/tests/e2e/lib/tests
+++ b/tests/e2e/lib/tests
@@ -18,22 +18,24 @@
 # along with this program; If not, see <http://www.gnu.org/licenses/>.
 #
 
-if [[ -n $NODES_FOR_TESTING_ARR ]]; then
-    readarray -d ' ' -t NODES_FOR_TESTING <<< "$NODES_FOR_TESTING_ARR"
-fi
+NODES_FOR_TESTING_ARR="${NODES_FOR_TESTING_ARR:-control qm-node1}"
+readarray -d ' ' -t NODES_FOR_TESTING <<< "$NODES_FOR_TESTING_ARR"
+
+CONTROL_CONTAINER_CMD=${CONTROL_CONTAINER_CMD:-podman exec}
+CONTROL_CONTAINER_NAME="${CONTROL_CONTAINER_NAME:-control}"
 
 test_bluechi_list_all_units() {
     for node_name in "${NODES_FOR_TESTING[@]}"
     do
         echo
         info_message "Connected to \033[92m${CONTROL_CONTAINER_NAME}\033[0m, listing few systemd units from \033[92m${node_name}\033[0m"
-        bluechictl_cmd=$(podman exec \
-		"${CONTROL_CONTAINER_NAME}" \
-		bluechictl \
-		list-units \
-		$(echo "${node_name}")
-	)
-	if_error_exit "unable to execute bluechictl command on ${CONTROL_CONTAINER_NAME}"
-	echo "${bluechictl_cmd}" | grep -E "container-|qm.service"
+        bluechictl_cmd=$(eval "${CONTROL_CONTAINER_CMD} \
+                ${CONTROL_CONTAINER_NAME} \
+                bluechictl \
+                list-units \
+                ${node_name}"
+        )
+        if_error_exit "unable to execute bluechictl command on ${CONTROL_CONTAINER_NAME}"
+        grep -E  "container-|qm.service" <<< ${bluechictl_cmd}
     done
 }

--- a/tests/e2e/tier-0.fmf
+++ b/tests/e2e/tier-0.fmf
@@ -1,4 +1,5 @@
 summary: Tier 0 - QM Interconnect through bluechi
+
 discover:
     how: fmf
     filter: tier:0
@@ -6,8 +7,8 @@ discover:
 provision:
    how: local
 
-when: distro == centos-stream-9
-prepare:
+adjust:
+   prepare+:
       - name: Prepare Repos
         how: shell
         script: |
@@ -18,16 +19,14 @@ prepare:
       - name: install repos
         how: install
         package:
-          - podman
+           - podman
 
       - name: Set QM env
         how: shell
         script: |
            cd tests/e2e
            ./run-test-e2e --skip-tests=yes
-
-context:
-    distro: qm
+   when: distro == centos-stream-9 or distro == fedora
 
 execute:
     how: tmt

--- a/tests/e2e/tier-0.fmf
+++ b/tests/e2e/tier-0.fmf
@@ -6,24 +6,25 @@ discover:
 provision:
    how: local
 
+when: distro == centos-stream-9
 prepare:
-  - name: Prepare Repos
-    how: shell
-    script: |
-        dnf install -y 	dnf-plugin-config-manager epel-release
-        dnf config-manager -y --set-enabled crb
-        dnf -y copr enable rhcontainerbot/qm centos-stream-9
+      - name: Prepare Repos
+        how: shell
+        script: |
+           dnf install -y dnf-plugin-config-manager epel-release
+           dnf config-manager -y --set-enabled crb
+           dnf -y copr enable rhcontainerbot/qm centos-stream-9
 
-  - name: install repos
-    how: install
-    package:
-      - podman
+      - name: install repos
+        how: install
+        package:
+          - podman
 
-  - name: Set QM env
-    how: shell
-    script: |
-        cd tests/e2e
-        bash ./run-test-e2e --skip-tests=yes
+      - name: Set QM env
+        how: shell
+        script: |
+           cd tests/e2e
+           ./run-test-e2e --skip-tests=yes
 
 context:
     distro: qm

--- a/tests/qm-connectivity/main.fmf
+++ b/tests/qm-connectivity/main.fmf
@@ -2,10 +2,6 @@ summary: Test is calling e2e/lib/tests as stand alone test
 test:
     ./test.sh
 
-environment:
-    NODES_FOR_TESTING_ARR: control node1
-    CONTROL_CONTAINER_NAME: "control"
-
 tier: 0
 
 framework:


### PR DESCRIPTION
The test run prepare step only on c9s and fedora
ENV variables changed based on the distro it is inquires.

Please take a look here for tmt extra keyes
https://tmt.readthedocs.io/en/latest/spec/core.html#adjust