### PR TITLE
Add CI test verify Quay AutoSD QM is working

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -63,7 +63,7 @@ jobs:
   - job: tests
     trigger: pull_request
     identifier: e2e
-    tmt_plan: /tests/e2e/tier-0
+    tmt_plan: /tests/e2e
     skip_build: true
     targets:
     - centos-stream-9-x86_64

--- a/tests/e2e/lib/tests
+++ b/tests/e2e/lib/tests
@@ -43,7 +43,7 @@ test_bluechi_list_all_units() {
         fi
         if_error_exit "unable to execute bluechictl command on ${CONTROL_CONTAINER_NAME}"
 
-        if [ "${CONTROL_CONTAINER_NAME}" = "host" ]; then
+        if [ "${CONTROL_CONTAINER_NAME}" = "host" -o "${CONTROL_CONTAINER_NAME}" = "autosd" ]; then
            grep -E  "bluechi|qm" <<< ${bluechictl_cmd}
         else
            grep -E  "container-|qm.service" <<< ${bluechictl_cmd}

--- a/tests/e2e/tier-1.fmf
+++ b/tests/e2e/tier-1.fmf
@@ -1,0 +1,29 @@
+summary: Tier 0 - QM Interconnect through bluechi
+
+discover:
+    how: fmf
+    filter: tier:1
+
+provision:
+   # Can not use provision no podman args
+   how: local
+
+adjust:
+   prepare+:
+      - name: Install rpms
+        how: install
+        package: podman
+      - name: Setp AutoSD env
+        how: shell
+        script: |
+           # Currently option passing c9s
+           podman run --replace -d --name autosd \
+                  --privileged -it \
+                  quay.io/centos-sig-automotive/autosd:latest
+   when: distro == centos-stream-9 or distro == fedora
+
+execute:
+    how: tmt
+
+report:
+    how: junit

--- a/tests/qm-connectivity/main.fmf
+++ b/tests/qm-connectivity/main.fmf
@@ -1,8 +1,19 @@
-summary: Test is calling e2e/lib/tests as stand alone test
 test:
-    ./test.sh
+  ./test.sh
 
-tier: 0
+/tier0:
+    summary: Test is calling e2e/lib/tests as stand alone test
+    test:
+      ./test.sh
+    tier: 0
 
+/tier1:
+    summary: Test is calling e2e/lib/tests AutoSD container
+    test:
+      ./test.sh
+    tier: 1
+    environment:
+      CONTROL_CONTAINER_NAME: "autosd"
+      NODES_FOR_TESTING_ARR: "localrootfs qm.localrootfs"
 framework:
     shell


### PR DESCRIPTION
Resolves #236

Add tier-1 tmt test
Verifies QM https://quay.io/repository/centos-sig-automotive/autosd
is up and running 