### PR TITLE
fix using skip-systemctl with other options

### DIFF
--- a/setup
+++ b/setup
@@ -214,6 +214,7 @@ echo  "  * rwetcfs: ${RWETCFS}"
 echo  "  * rwvarfs: ${RWVARFS}"
 echo  "  * install dir: ${INSTALLDIR}"
 echo  "  * skip-systemctl: ${SYSTEMCTL_SKIP}"
+echo  "  * agent hostname: ${AGENT_HOSTNAME}"
 echo
 
 case "$1" in

--- a/setup
+++ b/setup
@@ -160,7 +160,7 @@ install() {
 
 # read command line arguments
 opts=$(getopt \
-  --longoptions "$(printf "help,%s:," "${CMDLINE_ARGUMENT_LIST[@]}")" \
+  --longoptions "$(printf "help,skip-systemctl,%s:," "${CMDLINE_ARGUMENT_LIST[@]}")" \
   --name "$(basename "$0")" \
   --options "" \
   -- "$@"

--- a/tests/e2e/run-test-e2e
+++ b/tests/e2e/run-test-e2e
@@ -108,7 +108,7 @@ EOF
 
 # read arguments
 opts=$(getopt \
-    --longoptions "$(printf "help,%s:," "${ARGUMENT_LIST[@]}")" \
+    --longoptions "$(printf "help,skip-systemctl,%s:," "${ARGUMENT_LIST[@]}")" \
     --name "$(basename "$0")" \
     --options "" \
     -- "$@"


### PR DESCRIPTION
Adds `skip-systemctl,` so it can work with other cli options.