### PR TITLE
Fixing location of agent.conf

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -63,7 +63,7 @@ jobs:
   - job: tests
     trigger: pull_request
     identifier: e2e
-    tmt_plan: /plans/e2e
+    tmt_plan: /plans/e2e/tier-0
     skip_build: true
     targets:
     - centos-stream-9-x86_64

--- a/setup
+++ b/setup
@@ -12,7 +12,7 @@ ROOTFS="/usr/lib/qm/rootfs"
 RWETCFS="/etc/qm"
 RWVARFS="/var/qm"
 AGENT_HOSTNAME="$(hostname)"
-AGENTCONF="/etc/bluechi/agent.conf"
+AGENTCONF="/etc/bluechi/agent.conf.d/agent.conf"
 QM_CONTAINER_IDS=1000000000:1500000000
 CONTAINER_IDS=2500000000:1500000000
 


### PR DESCRIPTION
moving from /etc/bluechi/agent.conf ->
     /etc/bluechi/bluechi/agent.conf.d/
     
 resolve #248     
 since e2e/tier-1 test AutoSD image health, 
 This PR will not pass tests till autosd image build upload latest image https://gitlab.com/CentOS/automotive/container-images.git    
 
 
 depends #251 