### PR TITLE
Apply changes of bluechi configs in e2e containers

### DIFF
--- a/tests/e2e/lib/ContainerFile.template
+++ b/tests/e2e/lib/ContainerFile.template
@@ -97,8 +97,8 @@ RUN npm install markdownlint-cli2 --global
 
 # Upgrade the current bluechi using the new rpm packages but exclude src.rpm
 # [manually install bluechi] RUN find . -not -name *.src* -name *.rpm | xargs dnf install -y
-# RUN cp /usr/share/bluechi/config/controller.conf /etc/bluechi/controller.conf.d/controller.conf
-# [manually install bluechi] RUN cp /usr/share/bluechi/config/controller.conf /etc/bluechi/controller.conf
+# RUN cp /usr/share/bluechi/config/controller.conf /etc/bluechi/controller.conf.d/
+# [manually install bluechi] RUN cp /usr/share/bluechi/config/controller.conf /etc/bluechi/controller.conf.d/
 
 # [start] CONTROL - settings
 # Setting configuration, uncommenting:
@@ -106,21 +106,21 @@ RUN npm install markdownlint-cli2 --global
 #	- Use journal for logging
 #	- Set AllowedNodeNames as control and node1
 # TODO: remove the static node1 here, dynamic by rune2e script via sed
-RUN cp /usr/share/bluechi/config/controller.conf /etc/bluechi/
-RUN cp /usr/share/bluechi-agent/config/agent.conf /etc/bluechi/
+RUN cp /usr/share/bluechi/config/controller.conf /etc/bluechi/controller.conf.d/
+RUN cp /usr/share/bluechi-agent/config/agent.conf /etc/bluechi/agent.conf.d/
 RUN sed -e '/^#ManagerPort=/s/^#//g' \
 	-e '/#LogTarget/s/^#//' \
 	-e "s/^#AllowedNodeNames=/AllowedNodeNames=control,node1/" \
-	-i /etc/bluechi/controller.conf
+	-i /etc/bluechi/controller.conf.d/controller.conf
 # [end] CONTROL - settings
 
 RUN echo 'Foobar!' | passwd --stdin root
 
 # [start] CONTROL - agent settings
-RUN cp /usr/share/bluechi-agent/config/*.conf /etc/bluechi/ &> /dev/null
+RUN cp /usr/share/bluechi-agent/config/*.conf /etc/bluechi/agent.conf.d/ &> /dev/null
 RUN IPv4_CONTROL="$(ip -brief address show eth0 | awk '{print $3}' | awk -F/ '{print $1}')" && \
 	sed -e "s/^#NodeName=/NodeName=control/" \
-		-i /etc/bluechi/agent.conf
+		-i /etc/bluechi/agent.conf.d/agent.conf
 
 # [end] CONTROL - agent settings
 

--- a/tests/e2e/lib/container
+++ b/tests/e2e/lib/container
@@ -108,10 +108,10 @@ create_qm_node() {
         echo "RUN /usr/share/qm/setup --skip-systemctl true 2>&1 > /tmp/qm-setup.log || echo "QM setup failed, please check /tmp/qm-setup.log."" >> ContainerFile.node"${nodeID}"
 
         # Enable bluechi-agent
-        echo 'RUN cp /usr/share/bluechi-agent/config/*.conf /etc/bluechi/' >> ContainerFile.node"${nodeID}"
+        echo 'RUN cp /usr/share/bluechi-agent/config/*.conf /etc/bluechi/agent.conf.d/' >> ContainerFile.node"${nodeID}"
         echo 'RUN sed -i -e "s/^#NodeName=/NodeName='"node${nodeID}/"\" \
                 '-e "s/^#ManagerHost=/ManagerHost='"${IP_CONTROL_MACHINE}/"\" \
-                ' /etc/bluechi/agent.conf' >> ContainerFile.node"${nodeID}"
+                ' /etc/bluechi/agent.conf.d/agent.conf' >> ContainerFile.node"${nodeID}"
         echo "RUN systemctl enable bluechi-agent &> /dev/null" >> ContainerFile.node"${nodeID}"
 
         # Add systemd as CMD
@@ -145,7 +145,7 @@ create_qm_node() {
                 podman exec qm \
                 cp \
                 /usr/share/bluechi-agent/config/agent.conf \
-                /etc/bluechi/agent.conf
+                /etc/bluechi/agent.conf.d/agent.conf
         )"
         if_error_exit "unable to copy agent.conf template to agent.conf.d dir"
 
@@ -155,14 +155,14 @@ create_qm_node() {
         eval "$(podman exec node"${nodeID}" \
                 podman exec qm \
                 sed -i 's/^#ManagerHost=/ManagerHost='"${IP_CONTROL_MACHINE}"'/g' \
-                /etc/bluechi/agent.conf
+                /etc/bluechi/agent.conf.d/agent.conf
         )"
         if_error_exit "qm node: unable to sed ManagerHost in bluechi agent.conf"
 
         eval "$(podman exec node"${nodeID}" \
                 podman exec qm \
                 sed -i 's/^#NodeName=/NodeName='"${qm_node_name}"'/g' \
-                /etc/bluechi/agent.conf
+                /etc/bluechi/agent.conf.d/agent.conf
         )"
         if_error_exit "qm node: unable to sed NodeName in bluechi agent.conf"
 
@@ -182,7 +182,7 @@ create_qm_node() {
     # CONTROL NODE: append QM node into /etc/bluechi/agent.conf.din the control node the new qm node name
     eval "$(podman exec "${CONTROL_CONTAINER_NAME}" \
                 sed -i '/^AllowedNodeNames=/ s/$/,'"${AllowedNodeNames}"'/' \
-                /etc/bluechi/controller.conf
+                /etc/bluechi/controller.conf.d/controller.conf
     )"
     if_error_exit "control node: unable to sed AllowedNodeName in controller.conf"
 


### PR DESCRIPTION
e2e tier-0 started to fail probably due to updates in
Bluechi Configuration files
Updating config files in e2e tests setup

    moving from /etc/bluechi/agent.conf ->
         /etc/bluechi/agent.conf.d/
        
    moving from /etc/bluechi/controller.conf ->
         /etc/bluechi/controller.conf.d/
     
        