### PR TITLE
Fix ContainerFile.template errors

### DIFF
--- a/tests/e2e/lib/ContainerFile.template
+++ b/tests/e2e/lib/ContainerFile.template
@@ -44,7 +44,6 @@ RUN dnf install -y \
 	gzip \
 	jq \
 	tmt \
-	tmt-report-junit \
 	container-selinux \
 	kernel \
 	kernel-modules \

--- a/tests/e2e/set-ffi-env-e2e
+++ b/tests/e2e/set-ffi-env-e2e
@@ -38,8 +38,6 @@ export ARCH=""
 export BUILD_BLUECHI_FROM_GH_URL=""
 export QM_GH_URL=""
 export BRANCH_QM=""
-export BLUECHI_OVERRIDE_CONF="https://gitlab.com/CentOS/automotive/container-images/"
-       BLUECHI_OVERRIDE_CONF+="-/raw/main/images/autosd/files/etc/bluechi"
 
 if [ -t 1 ]; then
     RED='\033[91m'
@@ -139,10 +137,18 @@ setup_qm_services() {
   # Curl files into here,
   # Fix: default setup:main should be removed on next qm release
   /usr/share/qm/setup --hostname localrootfs
-  curl "${BLUECHI_OVERRIDE_CONF}/agent.conf.d/00-default.conf" > /etc/bluechi/agent.conf.d/00-default.conf
-  curl "${BLUECHI_OVERRIDE_CONF}/controller.conf.d/00-default.conf" > /etc/bluechi/controller.conf.d/00-default.conf
-  # move bluechi-agent.conf@qm to correct place
-  mv /etc/qm/bluechi/agent.conf /etc/qm/bluechi/agent.conf.d/agent.conf
+  cat > /etc/bluechi/controller.conf.d/00-default.conf << 'EOF'
+[bluechi-controller]
+AllowedNodeNames=qm.localrootfs,localrootfs
+ManagerPort=842
+LogLevel=INFO
+LogTarget=journald
+LogIsQuiet=false
+EOF
+cat > /etc/bluechi/agent.conf.d/00-default.conf << 'EOF'
+[bluechi-agent]
+NodeName=localrootfs
+EOF
   # Enable services
   systemctl enable bluechi-controller
   systemctl enable bluechi-agent


### PR DESCRIPTION
Resolve 1st issue in #253 

CI started to FAIL on dnf install
Unable to find a match: tmt-report-junit, removed it for now

CI failing due to curl configuration files, which are not accessible to public.
Replace curl configuration of bluechi entities with coded default config