### PR TITLE
e2e: add iptables-nft to control/nodeX nodes

### DIFF
--- a/tests/e2e/lib/ContainerFile.template
+++ b/tests/e2e/lib/ContainerFile.template
@@ -32,6 +32,7 @@ RUN dnf install -y \
 	sudo \
 	gpgme-devel \
 	libseccomp-devel \
+	iptables-nft \
 	iptables-services \
 	selinux-policy-targeted \
 	selinux-policy-devel \


### PR DESCRIPTION
To avoid container startup issues with iptables legacy let's make sure control and node1 contain iptables-nft.