### PR TITLE
e2e: replace systemd stubs with quadlet

### DIFF
--- a/tests/e2e/lib/quadlet/container-template.container
+++ b/tests/e2e/lib/quadlet/container-template.container
@@ -1,0 +1,11 @@
+[Unit]
+Description=The sleep container
+After=local-fs.target
+
+[Container]
+Image=registry.access.redhat.com/ubi9-minimal:latest
+Exec=sleep infinity
+
+[Install]
+# Start by default on boot
+WantedBy=multi-user.target default.target

--- a/tests/e2e/lib/systemd
+++ b/tests/e2e/lib/systemd
@@ -34,90 +34,49 @@ create_stub_systemd_srv() {
              continue
         fi
 
+	# QM container
         if [ -n "${creates_on_qm_node}" ]; then
-            info_message "Creating stub systemd service: \033[92mcontainer-${srv}\033[0m in \033[92m${container_target}\033[0m and moving it to container \033[92mqm\033[0m inside \033[92m${container_target}\033[0m"
-        else
-            info_message "Creating stub systemd service: \033[92mcontainer-${srv}\033[0m in container \033[92m${container_target}\033[0m. It might take some time..."
-        fi
-
-        # create stub pod for the service
-        cmd_create_pod="podman exec ${container_target} \
-podman create --name ${srv} \
-${REGISTRY_UBI8_MINIMAL} \
-sleep infinity"
-        #echo "${cmd_create_pod}"
-        eval "${cmd_create_pod}" 1> /dev/null
-        if_error_exit "cannot create container ${srv} in target ${container_target}"
-
-        if [ -n "${creates_on_qm_node}" ]; then
-            # FIXME: podman generate systemd --files generates the systemd file in the dir it's running. As we are running in a read-only FS in QM container, we must generate
-            # in node1 and copy later to /etc/systemd/system
-            cmd_gen_systemd_srv="podman exec ${container_target} \
-podman generate systemd \
---new \
---files \
---name ${srv}"
-            #echo "${cmd_gen_systemd_srv}"
-            eval "${cmd_gen_systemd_srv}" &> /dev/null
-            if_error_exit "cannot generate systemd srv: ${srv} in container ${container_target}"
-
-            cmd_cp_systemd_srv="podman exec ${container_target} \
-podman \
+            info_message "Creating quadlet container file: \033[92mcontainer-${srv}\033[0m in \033[92m${container_target}\033[0m and moving it to container \033[92mqm\033[0m to start the quadlet service..."
+            cmd_cp_systemd_srv="podman \
 cp \
-container-${srv}.service \
-qm:/etc/systemd/system"
-            #echo "${cmd_cp_systemd_srv}"
-            eval "${cmd_cp_systemd_srv}" &> /dev/null
-            if_error_exit "cannot copy container-${srv} service to qm container"
+lib/quadlet/container-template.container \
+${container_target}:/tmp/container-${srv}.container"
+             #echo "${cmd_cp_systemd_srv}"
+             eval "${cmd_cp_systemd_srv}"
+             if_error_exit "cannot copy container-${srv} to qm container"
 
-            cmd_rm_systemd_srv="podman exec ${container_target} \
-rm \
-container-${srv}.service"
-            #echo "${cmd_rm_systemd_srv}"
-            eval "${cmd_rm_systemd_srv}" &> /dev/null
-            if_error_exit "cannot remove temporary systemd service generated"
+	     # START: remove DropCapability to run nested container
+             podman exec -it ${container_target} sed -i '/^\s*DropCapability=sys_resource/ d' /etc/containers/systemd/qm.container
+	     if_error_exit "unable to remove DropCapability=sys_resource in qm.container"
+
+	     podman exec -it ${container_target} systemctl daemon-reload
+	     if_error_exit "unable to execute daemon-reload"
+
+	     podman exec -it ${container_target} systemctl restart qm
+	     if_error_exit "unable to restart qm service"
+	     # END: remove DropCapability to run nested container
+
+	     # START: copy template quadlet to qm container
+	     podman exec -it ${container_target} podman cp /tmp/container-${srv}.container qm:/etc/containers/systemd
+	     if_error_exit "unable to copy container-${srv}.container to qm container"
+
+	     podman exec -it ${container_target} podman exec -it qm systemctl daemon-reload
+	     if_error_exit "unable to execute on qm container systemctl daemon-reload"
+
+	     podman exec -it ${container_target} podman exec -it qm systemctl start container-${srv}
+	     if_error_exit "unable to start the quadlet service container-${srv}"
+
+	     # END: copy template quadlet to qm container
+	# Not a QM container, example: bluechi-controller
         else
-            # generate systemd service from the stub just created (reminder: inside the pod)
-            cmd_generate_systemd_srv="podman exec ${container_target} \
-podman generate systemd \
---new \
---files \
---name ${srv}"
-            #echo "${cmd_generate_systemd_srv}"
-            eval "${cmd_generate_systemd_srv}" &> /dev/null
-            if_error_exit "cannot generate systemd service ${srv} in ${container_target}"
-            # move the new systemd file to /etc/systemd/system
-            cmd_move_systemd_files="podman exec ${container_target} \
-${command_on_qm_node} \
-mv container-${srv}.service \
-/usr/lib/systemd/system"
-            #echo "${cmd_move_systemd_files}"
-            eval "${cmd_move_systemd_files}" &> /dev/null
-            if_error_exit "cannot move ${srv}-service to systemd dir in ${container_target}"
+             info_message "Creating and starting quadlet container: \033[92mcontainer-${srv}\033[0m in \033[92m${container_target}\033[0m. It might take some time..."
+	     cmd_cp_systemd_serv="podman \
+cp \
+lib/quadlet/container-template.container \
+${container_target}:/etc/containers/systemd/container-${srv}.container"
+             #echo "${cmd_cp_systemd_serv}"
+             eval "${cmd_cp_systemd_serv}"
+             if_error_exit "cannot copy container-${srv} to ${container_target} container"
         fi
-
-        # enable the new systemd service (inside pod)
-        cmd_enable_systemd_srv="podman exec ${container_target} \
-${command_on_qm_node} \
-systemctl \
-enable \
-container-${srv}"
-        #echo "${cmd_enable_systemd_srv}"
-        eval "${cmd_enable_systemd_srv}" &> /dev/null
-        if_error_exit "cannot enable ${srv}-service in ${container_target}"
-
-        # start the service (inside pod)
-        cmd_start_systemd_srv="podman exec ${container_target} \
-${command_on_qm_node} \
-systemctl \
-start \
-container-${srv}"
-        #echo "${cmd_start_systemd_srv}"
-        eval "${cmd_start_systemd_srv}" &> /dev/null
-        container_stat=$(systemctl is-active container-"${srv}")
-        if [[ "${container_stat}" != "activating" ]]; then
-           sleep 5
-        fi
-        if_error_exit "cannot start ${srv}-service in ${container_target}"
     done
 }


### PR DESCRIPTION
podman generating systemd services is deprecated.
This patch uses quadlet container file to reproduce an auto environment in a nested container.