### PR TITLE
Fix current run-test-e2e

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -64,7 +64,6 @@ jobs:
     trigger: pull_request
     identifier: e2e-tiers
     tmt_plan: /plans/e2e/tier-0
-    skip_build: true
     targets:
     - centos-stream-9-x86_64
     tf_extra_params:
@@ -78,7 +77,6 @@ jobs:
     trigger: pull_request
     identifier: e2e-ffi
     tmt_plan: /plans/e2e/ffi
-    skip_build: true
     targets:
     - centos-stream-9-x86_64
     tf_extra_params:

--- a/plans/e2e/ffi.fmf
+++ b/plans/e2e/ffi.fmf
@@ -11,6 +11,10 @@ provision:
    how: local
 
 adjust:
+ - when: run == manual
+   environment+:
+       USE_QM_COPR: yes
+ - when: scenario == ffi and distro == centos-stream-9, fedora
    prepare+:
       - name: Install rpms
         how: install
@@ -23,7 +27,6 @@ adjust:
         script: |
            cd tests/e2e
            ./set-ffi-env-e2e --set-qm-disk-part=yes
-   when: scenario == ffi and distro == centos-stream-9, fedora
 
 execute:
     how: tmt

--- a/plans/e2e/ffi.fmf
+++ b/plans/e2e/ffi.fmf
@@ -22,7 +22,7 @@ adjust:
            # qm-setup-from-gh-url, branch-qm option
         script: |
            cd tests/e2e
-           ./set-ffi-env-e2e --branch-qm=main --qm-setup-from-gh-url=https://raw.githubusercontent.com/containers --set-qm-disk-part=yes
+           ./set-ffi-env-e2e --set-qm-disk-part=yes
    when: scenario == ffi and distro == centos-stream-9, fedora
 
 execute:

--- a/plans/e2e/ffi.fmf
+++ b/plans/e2e/ffi.fmf
@@ -13,7 +13,8 @@ provision:
 adjust:
  - when: run == manual
    environment+:
-       USE_QM_COPR: yes
+       # Sample code to use manual packit repo
+       PACKIT_COPR_PROJECT: packit/containers-qm-291
  - when: scenario == ffi and distro == centos-stream-9, fedora
    prepare+:
       - name: Install rpms

--- a/plans/e2e/tier-0.fmf
+++ b/plans/e2e/tier-0.fmf
@@ -10,13 +10,8 @@ provision:
 adjust:
  - when: run == manual
    environment+:
-       USE_QM_COPR: yes
-   prepare+:
-     - name: Prepare QM Repos
-       how: shell
-       order: 10
-       script: |
-          dnf copr enable -y rhcontainerbot/qm centos-stream-9
+       # Sample code to use manual packit repo
+       PACKIT_COPR_PROJECT: packit/containers-qm-291
 
  - when: distro == centos-stream-9 or distro == fedora
    prepare+:

--- a/plans/e2e/tier-0.fmf
+++ b/plans/e2e/tier-0.fmf
@@ -8,25 +8,32 @@ provision:
    how: local
 
 adjust:
+ - when: scenario == manual
    prepare+:
-      - name: Prepare Repos
-        how: shell
-        script: |
-           dnf install -y dnf-plugin-config-manager epel-release
-           dnf config-manager -y --set-enabled crb
-           dnf -y copr enable rhcontainerbot/qm centos-stream-9
+     - name: Prepare Repos
+       how: shell
+       order: 10
+       script: |
+          dnf copr enable -y rhcontainerbot/qm centos-stream-9
 
-      - name: install repos
-        how: install
-        package:
-           - podman
+ - when: distro == centos-stream-9 or distro == fedora
+   prepare+:
+     - name: Prepare Repos
+       how: shell
+       script: |
+          dnf install -y dnf-plugin-config-manager epel-release
+          dnf config-manager -y --set-enabled crb
 
-      - name: Set QM env
-        how: shell
-        script: |
-           cd tests/e2e
-           ./run-test-e2e --skip-tests=yes
-   when: distro == centos-stream-9 or distro == fedora
+     - name: install repos
+       how: install
+       package:
+          - podman
+
+     - name: Set QM env
+       how: shell
+       script: |
+          cd tests/e2e
+          ./run-test-e2e --skip-tests=yes
 
 execute:
     how: tmt

--- a/plans/e2e/tier-0.fmf
+++ b/plans/e2e/tier-0.fmf
@@ -8,9 +8,11 @@ provision:
    how: local
 
 adjust:
- - when: scenario == manual
+ - when: run == manual
+   environment+:
+       USE_QM_COPR: yes
    prepare+:
-     - name: Prepare Repos
+     - name: Prepare QM Repos
        how: shell
        order: 10
        script: |

--- a/setup
+++ b/setup
@@ -11,7 +11,7 @@ INSTALLDIR="/usr/share/qm"
 ROOTFS="/usr/lib/qm/rootfs"
 RWETCFS="/etc/qm"
 RWVARFS="/var/qm"
-TMP_QM_IMG_DIR="tmp-img-dir"
+TMP_QM_IMG_DIR="tmp.images"
 AGENT_HOSTNAME="$(hostname)"
 AGENTCONF="/etc/bluechi/agent.conf.d/agent.conf"
 QM_CONTAINER_IDS=1000000000:1500000000
@@ -98,12 +98,16 @@ storage() {
 	touch "${ROOTFS}/var/lib/shared/overlay-images/images.lock" \
 	      "${ROOTFS}/var/lib/shared/overlay-layers/layers.lock"
 
-	sed -e '/additionalimage.*/a "/var/lib/shared",' \
-	    -e 's|^#.*transient_store.*|transient_store=true|g' \
-	    "${ROOTFS}/usr/share/containers/storage.conf" \
-	    > "${ROOTFS}/etc/containers/storage.conf"
-        sed -i "s|^#env = \[\]|env = \[\"TMPDIR=/var/${TMP_QM_IMG_DIR}\"\]|" \
-            "${ROOTFS}/usr/share/containers/containers.conf"
+        sed -e '/additionalimage.*/,/]/s/^#//g' \
+            -e '/additionalimages.*/{n;s/.*/\"\/var\/lib\/shared\",/;}' \
+            -e 's|^#.*transient_store.*|transient_store=true|g' \
+            /"${ROOTFS}/usr/share/containers/storage.conf" \
+            > "${ROOTFS}/etc/containers/storage.conf"
+
+        if ! grep -q "env" "${ROOTFS}/etc/containers/containers.conf"; then
+            echo "env = [\"TMPDIR=/var/${TMP_QM_IMG_DIR}\"]" \
+            >>  "${ROOTFS}/etc/containers/containers.conf"
+        fi
     fi
 }
 

--- a/tests/e2e/lib/ContainerFile.template
+++ b/tests/e2e/lib/ContainerFile.template
@@ -5,7 +5,6 @@ RUN dnf install -y \
 	epel-release
 
 RUN dnf config-manager -y --set-enabled crb
-RUN dnf -y copr enable rhcontainerbot/qm centos-stream-9
 RUN dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
 
 RUN dnf install -y \

--- a/tests/e2e/lib/container
+++ b/tests/e2e/lib/container
@@ -75,13 +75,13 @@ imageID: ${IMAGE_ID}"
 
 setup_node() {
         local nodeID="${1}"
-        local use_qm_copr="${2}"
+        local use_copr_repo="${2}"
 
         # copy control as template to node${number}
         cp ./lib/ContainerFile.template ContainerFile.node"${nodeID}"
         if_error_exit "failed to copy ContainerFile control template to node!"
-        if [ -n ${use_qm_copr} ]; then
-          sed -e 's/crb/&\nRUN dnf -y copr enable rhcontainerbot\/qm centos-stream-9/' -i ContainerFile.node"${nodeID}"
+        if [ -n "${use_copr_repo}" ]; then
+          sed -e "/crb/a RUN dnf -y copr enable ${use_copr_repo} centos-stream-9" -i ContainerFile.node"${nodeID}"
           if_error_exit "failed to sed ContainerFile node template!"
         fi
         # remove specific code from control mode (template)

--- a/tests/e2e/lib/container
+++ b/tests/e2e/lib/container
@@ -80,7 +80,7 @@ setup_node() {
         # copy control as template to node${number}
         cp ./lib/ContainerFile.template ContainerFile.node"${nodeID}"
         if_error_exit "failed to copy ContainerFile control template to node!"
-        if [ -n ${use_qm-copr} ]; then
+        if [ -n ${use_qm_copr} ]; then
           sed -e 's/crb/&\nRUN dnf -y copr enable rhcontainerbot\/qm centos-stream-9/' -i ContainerFile.node"${nodeID}"
           if_error_exit "failed to sed ContainerFile node template!"
         fi

--- a/tests/e2e/lib/container
+++ b/tests/e2e/lib/container
@@ -75,13 +75,17 @@ imageID: ${IMAGE_ID}"
 
 setup_node() {
         local nodeID="${1}"
+        local use_qm_copr="${2}"
 
         # copy control as template to node${number}
         cp ./lib/ContainerFile.template ContainerFile.node"${nodeID}"
         if_error_exit "failed to copy ContainerFile control template to node!"
-
+        if [ -n ${use_qm-copr} ]; then
+          sed -e 's/crb/&\nRUN dnf -y copr enable rhcontainerbot\/qm centos-stream-9/' -i ContainerFile.node"${nodeID}"
+          if_error_exit "failed to sed ContainerFile node template!"
+        fi
         # remove specific code from control mode (template)
-        sed -i '/start/,/end/d' ContainerFile.node"${nodeID}"
+        sed '/start/,/end/d' -i ContainerFile.node"${nodeID}"
         if_error_exit "failed to sed ContainerFile node template!"
 }
 
@@ -97,10 +101,14 @@ create_qm_node() {
 
         setup_node \
             "${nodeID}" \
-            "${IP_CONTROL_MACHINE}"
-
+            "${USE_QM_COPR}"
         # Add final instructions
         echo "RUN dnf install qm -y &> /dev/null" >> ContainerFile.node"${nodeID}"
+
+        if [ -n "${QM_GH_URL}" ]; then
+          curl "${QM_GH_URL}"  > /usr/share/qm/setup
+          chmod +x /usr/share/qm/setup
+        fi
 
         # Execute qm setup
         # Use --skip-systemctl true in podman build, systemd is not running

--- a/tests/e2e/lib/systemd
+++ b/tests/e2e/lib/systemd
@@ -45,8 +45,10 @@ ${container_target}:/tmp/container-${srv}.container"
              eval "${cmd_cp_systemd_srv}"
              if_error_exit "cannot copy container-${srv} to qm container"
 
+             # Find configuration file from service
+             target_service_file=$(podman exec ${container_target} systemctl show -P  SourcePath qm.service)
 	     # START: remove DropCapability to run nested container
-             podman exec -it ${container_target} sed -i '/^\s*DropCapability=sys_resource/ d' /etc/containers/systemd/qm.container
+             podman exec -it ${container_target} bash -c "sed -i '/^\s*DropCapability=sys_resource/ d' \"${target_service_file}\""
 	     if_error_exit "unable to remove DropCapability=sys_resource in qm.container"
 
 	     podman exec -it ${container_target} systemctl daemon-reload

--- a/tests/e2e/run-test-e2e
+++ b/tests/e2e/run-test-e2e
@@ -39,7 +39,7 @@ export BUILD_QM_FROM_GH_URL=""
 export BUILD_BLUECHI_FROM_GH_URL=""
 export BRANCH_BLUECHI=""
 export BRANCH_QM=""
-export USE_QM_COPR="${USE_QM_COPR:-}"
+export USE_QM_COPR="${PACKIT_COPR_PROJECT:-rhcontainerbot/qm}"
 
 # If no additional nodes are required, use 1
 if [ -z "${NUMBER_OF_NODES}" ]; then

--- a/tests/e2e/run-test-e2e
+++ b/tests/e2e/run-test-e2e
@@ -17,6 +17,8 @@
 # along with this program; If not, see <http://www.gnu.org/licenses/>.
 #
 # Capture the start time
+set -vx
+
 START_TIME=$(date +%s)
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
@@ -38,6 +40,7 @@ export BUILD_QM_FROM_GH_URL=""
 export BUILD_BLUECHI_FROM_GH_URL=""
 export BRANCH_BLUECHI=""
 export BRANCH_QM=""
+export USE_QM_COPR=""
 
 # If no additional nodes are required, use 1
 if [ -z "${NUMBER_OF_NODES}" ]; then
@@ -62,6 +65,7 @@ fi
 ARGUMENT_LIST=(
     "build-qm-from-gh-url"
     "branch-qm"
+    "use-qm-copr"
     "build-bluechi-from-gh-url"
     "branch-bluechi"
     "skip-tests"
@@ -79,7 +83,8 @@ Usage: ./run-test-e2e [OPTIONS]
 	Build QM from a specific GitHub URL, useful for testing new features
 --branch-qm
 	Specify which branch the GitHub repo will be set. Requires --build-qm-from-gh-url
-
+--use-qm-copr
+        Specify to install rpms from rhcontainerbot/qm copr
 --number-of-nodes
 	Specify number of nodes. (default 1)
 
@@ -101,6 +106,7 @@ Examples:
 			--build-qm-from-gh-url=https://github.com/MYUSER/qm.git \\
 			--branch-bluechi=superfeature \\
 			--build-bluechi-from-gh-url=https://github.com/MYUSER/bluechi.git \\
+			--use-qm-copr=Y \\
 
 EOF
     exit 0
@@ -157,6 +163,12 @@ while [ $# -gt 0 ]; do
 
             shift 2
             ;;
+
+        --use-qm-copr)
+            USE_QM_COPR="${2}"
+            shift 2
+            ;;
+
 
         --help)
             usage

--- a/tests/e2e/run-test-e2e
+++ b/tests/e2e/run-test-e2e
@@ -17,7 +17,6 @@
 # along with this program; If not, see <http://www.gnu.org/licenses/>.
 #
 # Capture the start time
-set -vx
 
 START_TIME=$(date +%s)
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
@@ -40,7 +39,7 @@ export BUILD_QM_FROM_GH_URL=""
 export BUILD_BLUECHI_FROM_GH_URL=""
 export BRANCH_BLUECHI=""
 export BRANCH_QM=""
-export USE_QM_COPR=""
+export USE_QM_COPR="${USE_QM_COPR:-}"
 
 # If no additional nodes are required, use 1
 if [ -z "${NUMBER_OF_NODES}" ]; then

--- a/tests/e2e/set-ffi-env-e2e
+++ b/tests/e2e/set-ffi-env-e2e
@@ -46,6 +46,7 @@ export BUILD_BLUECHI_FROM_GH_URL=""
 export QM_GH_URL=""
 export BRANCH_QM=""
 export SET_QM_PART=""
+export USE_QM_COPR=""
 
 RED='\033[91m'
 GRN='\033[92m'
@@ -56,6 +57,7 @@ ARGUMENT_LIST=(
     "qm-setup-from-gh-url"
     "branch-qm"
     "set-qm-disk-part"
+    "use-qm-copr"
 )
 
 usage() {
@@ -74,16 +76,20 @@ Usage: ./set-ffi-env-e2e [OPTIONS]
 --set-qm-disk-part
         Specify if disk partition neede for /var/qm needed
 
+--use-qm-copr
+        Specify to install rpms from rhcontainerbot/qm copr
+
 Examples:
 
 	No args, it will install latest qm and bluechi from copr rpm repository
 		./set-ffi-env-e2e
 
-        Usee qm setup specific github url and select the branches
+        Use qm setup specific github url and select the branches
                 ./set-ffi-env-e2e \\
                         --branch-qm=superfeature \\
                         --qm-setup-from-gh-url=https://raw.githubusercontent.com/MYUSER/ \\
                         --set-qm-disk-part=Y \\
+                        --use-qm-copr=Y \\
 
 EOF
     exit 0
@@ -116,6 +122,11 @@ while [ $# -gt 0 ]; do
 
         --set-qm-disk-part)
             SET_QM_PART="${2}"
+            shift 2
+            ;;
+
+        --use-qm-copr)
+            USE_QM_COPR="${2}"
             shift 2
             ;;
 
@@ -159,7 +170,9 @@ install_qm_rpms() {
   dnf install -y 'dnf-command(config-manager)'
   dnf config-manager --set-enabled crb
   dnf copr enable -y @centos-automotive-sig/bluechi-snapshot centos-stream-9-"${ARCH}"
-  dnf copr enable -y rhcontainerbot/qm centos-stream-9-"${ARCH}"
+  if [ -n "${USE_QM_COPR}" ]; then
+      dnf copr enable -y rhcontainerbot/qm centos-stream-9-"${ARCH}"
+  fi
   dnf install -y qm bluechi-ctl bluechi podman hostname
 }
 

--- a/tests/e2e/set-ffi-env-e2e
+++ b/tests/e2e/set-ffi-env-e2e
@@ -46,7 +46,7 @@ export BUILD_BLUECHI_FROM_GH_URL=""
 export QM_GH_URL=""
 export BRANCH_QM=""
 export SET_QM_PART=""
-export USE_QM_COPR=""
+export USE_QM_COPR="${USE_QM_COPR:-}"
 
 RED='\033[91m'
 GRN='\033[92m'

--- a/tests/e2e/set-ffi-env-e2e
+++ b/tests/e2e/set-ffi-env-e2e
@@ -46,7 +46,7 @@ export BUILD_BLUECHI_FROM_GH_URL=""
 export QM_GH_URL=""
 export BRANCH_QM=""
 export SET_QM_PART=""
-export USE_QM_COPR="${USE_QM_COPR:-}"
+export USE_QM_COPR="${PACKIT_COPR_PROJECT:-rhcontainerbot/qm}"
 
 RED='\033[91m'
 GRN='\033[92m'
@@ -171,7 +171,7 @@ install_qm_rpms() {
   dnf config-manager --set-enabled crb
   dnf copr enable -y @centos-automotive-sig/bluechi-snapshot centos-stream-9-"${ARCH}"
   if [ -n "${USE_QM_COPR}" ]; then
-      dnf copr enable -y rhcontainerbot/qm centos-stream-9-"${ARCH}"
+      dnf copr enable -y "${USE_QM_COPR}" centos-stream-9-"${ARCH}"
   fi
   dnf install -y qm bluechi-ctl bluechi podman hostname
 }


### PR DESCRIPTION
Resolves #290 and Resolves #288 
Currently tests are not using packit repo created by previous steps Added an option for scripts --use-qm-copr to 
For containers build, if PACKIT_COPR_PROJECT exist while running under packit pipeline, the repo is enabled and install PR qn rpm

be used while running tests with rhcontainerbot/qm, default is using packit rpms, triggered by scenario=manual parsed in context scenario == manual

