### PR TITLE
Updating old dependency in hirte-agent

### DIFF
--- a/rpm/qm.spec
+++ b/rpm/qm.spec
@@ -71,7 +71,7 @@ Requires(post): libselinux-utils
 %if %{with podman_45}
 Requires: podman >= %{podman_epoch}:4.5
 %endif
-Requires: hirte-agent
+Requires: bluechi-agent
 
 %description
 This package allow users to setup an environment which prevents applications

--- a/setup
+++ b/setup
@@ -86,16 +86,15 @@ bluechiSetup() {
 NodeName=qm.${hostname}
 EOF
     fi
-    umount "${ROOTFS}/var" "${ROOTFS}/etc"
 }
 
 storage() {
     ROOTFS=$1
     if ! test -f "${ROOTFS}/etc/containers/storage.conf"; then
 	mkdir -p "${ROOTFS}/var/lib/shared/overlay-images" \
-	      "${ROOTFS}/var/lib/shared/overlay-layers" \
-              "${ROOTFS}/var/${TMP_QM_IMG_DIR}"
-	touch "${ROOTFS}/var/lib/shared/overlay-images/images.lock" \
+	      "${ROOTFS}/var/lib/shared/overlay-layers"
+
+        touch "${ROOTFS}/var/lib/shared/overlay-images/images.lock" \
 	      "${ROOTFS}/var/lib/shared/overlay-layers/layers.lock"
 
         sed -e '/additionalimage.*/,/]/s/^#//g' \
@@ -103,11 +102,16 @@ storage() {
             -e 's|^#.*transient_store.*|transient_store=true|g' \
             /"${ROOTFS}/usr/share/containers/storage.conf" \
             > "${ROOTFS}/etc/containers/storage.conf"
+    fi
 
-        if ! grep -q "env" "${ROOTFS}/etc/containers/containers.conf"; then
-            echo "env = [\"TMPDIR=/var/${TMP_QM_IMG_DIR}\"]" \
-            >>  "${ROOTFS}/etc/containers/containers.conf"
-        fi
+    #File always copied from /usr/share/qm, check if exist and append
+    if test -f "${ROOTFS}/etc/containers/containers.conf"; then
+        mkdir -p "${ROOTFS}/var/${TMP_QM_IMG_DIR}"
+        cat >> "${ROOTFS}/etc/containers/containers.conf" <<EOF
+
+[engine]
+env = ["TMPDIR=/var/${TMP_QM_IMG_DIR}"]
+EOF
     fi
 }
 

--- a/tests/e2e/lib/tests
+++ b/tests/e2e/lib/tests
@@ -20,8 +20,8 @@
 
 NODES_FOR_TESTING_ARR="${NODES_FOR_TESTING_ARR:-control qm-node1}"
 readarray -d ' ' -t NODES_FOR_TESTING <<< "$NODES_FOR_TESTING_ARR"
-
 CONTROL_CONTAINER_NAME="${CONTROL_CONTAINER_NAME:-control}"
+WAIT_BLUECHI_AGENT_CONNECT="${WAIT_BLUECHI_AGENT_CONNECT:-5}"
 
 test_bluechi_list_all_units() {
 
@@ -35,7 +35,9 @@ test_bluechi_list_all_units() {
            bluechictl_cmd="bluechictl list-units ${node_name}"
         else
            # It could take some time for qm bluechi-agent to connect
-           sleep 5
+           if [[ "${node_name}" =~ .*qm.* ]];then
+              sleep "${WAIT_BLUECHI_AGENT_CONNECT}"
+           fi
            bluechictl_cmd="podman exec"
            bluechictl_cmd+=" ${CONTROL_CONTAINER_NAME}"
            bluechictl_cmd+=" bluechictl list-units ${node_name}"

--- a/tests/e2e/lib/tests
+++ b/tests/e2e/lib/tests
@@ -34,10 +34,11 @@ test_bluechi_list_all_units() {
         if [ "${CONTROL_CONTAINER_NAME}" == "host" ]; then
            bluechictl_cmd="bluechictl list-units ${node_name}"
         else
+           # It could take some time for qm bluechi-agent to connect
+           sleep 5
            bluechictl_cmd="podman exec"
            bluechictl_cmd+=" ${CONTROL_CONTAINER_NAME}"
            bluechictl_cmd+=" bluechictl list-units ${node_name}"
-           sleep 1
         fi
         cmd_result=$(eval "${bluechictl_cmd}")
 

--- a/tests/e2e/set-ffi-env-e2e
+++ b/tests/e2e/set-ffi-env-e2e
@@ -145,9 +145,12 @@ create_qm_disks() {
   local disk_table
   disk_table=$(lsblk --noheadings --raw)
   local disks_arr
+  local slash_var
+  slash_var="/var"
   disks_arr=$(echo "$disk_table" | awk '$1~// && $6=="disk" {print $1}')
+  info_message "Create_qm_disks, found ${disks_arr}"
+  info_message "=============================="
 
-  mkdir /var/qm
   for disk in $disks_arr; do
      if [[ ${disk} == "vda" || \
            $(echo "${disk_table}" | grep -c "${disk}" ) -eq 1 && ${disk} != "zram0" ]];then
@@ -157,8 +160,18 @@ create_qm_disks() {
            part_id=p${part_id}
          fi
          mkfs.xfs "/dev/${disk}${part_id}"
-         mount "/dev/${disk}${part_id}" /var/qm
-         xfs_growfs /var/qm
+         info_message "Create_qm_disks, prepare and mount /new_var"
+         info_message "=============================="
+         mkdir -p /new_var
+         mount "/dev/${disk}${part_id}" /new_var
+         rsync -aqxP /var/* /new_var
+         systemctl stop var-lib-nfs-rpc_pipefs.mount
+         umount /new_var
+         rm -rf "${slash_var:?}"/*
+         info_message "Create_qm_disks, prepare and mount ${slash_var}"
+         info_message "=============================="
+         mount "/dev/${disk}${part_id}" "${slash_var}"
+         systemctl start var-lib-nfs-rpc_pipefs.mount
      fi
   done
 }
@@ -166,6 +179,8 @@ create_qm_disks() {
 install_qm_rpms() {
 
   info_message "Installing qm setup rpm"
+  info_message "Installing qm using ${USE_QM_COPR} repo"
+  info_message "=============================="
   ARCH=$(arch)
   dnf install -y 'dnf-command(config-manager)'
   dnf config-manager --set-enabled crb
@@ -179,6 +194,7 @@ install_qm_rpms() {
 setup_qm_services() {
 
   info_message "Setup qm services"
+  info_message "=============================="
   #Update setup script from QM repos, in case rpm not updates yet
   if [ -n "${QM_GH_URL}" ]; then
       curl "${QM_GH_URL}"  > /usr/share/qm/setup
@@ -200,9 +216,13 @@ cat > /etc/bluechi/agent.conf.d/00-default.conf << 'EOF'
 NodeName=localrootfs
 EOF
   # Enable services
+  info_message "Setup qm services, enable bluechi services"
+  info_message "=============================="
   systemctl enable bluechi-controller
   systemctl enable bluechi-agent
   # Start services
+  info_message "Setup qm services, start bluechi services"
+  info_message "=============================="
   systemctl start bluechi-controller
   systemctl start bluechi-agent
   # Restart qm to read lates bluechi-agent.conf


### PR DESCRIPTION
rename hirte-agent -> bluechi-agent

Resolve #293 

Adding fix related to CopyTmpImages dir was non under the right section
Adding fix for renaming /var/qm partition -> /var

Adding fix, for umount $ROOTFS/var $ROOTFS/etc it is called to earl,y thus could not create files/vars under 
$ROOTFS/var directory
