### PR TITLE
lib: add python3-dasbus into Container template

### DIFF
--- a/tests/e2e/lib/ContainerFile.template
+++ b/tests/e2e/lib/ContainerFile.template
@@ -26,6 +26,7 @@ RUN dnf install -y \
 	python3-flake8 \
 	python3-pytest \
 	python3-pytest-timeout \
+	python3-dasbus \
 	pre-commit \
 	pcp \
 	sudo \


### PR DESCRIPTION
Now it's possible to run bluechi stress test