### PR TITLE
qm.container: comment DropCapability

### DIFF
--- a/qm.container
+++ b/qm.container
@@ -23,7 +23,7 @@ TasksMax=50%
 AddCapability=all
 
 # Comment DropCapability this will allow FFI Tools to surpass their defaults.
-DropCapability=sys_resource
+# DropCapability=sys_resource
 
 AddDevice=-/dev/kvm
 AddDevice=-/dev/fuse


### PR DESCRIPTION
There is errors running podman (OCI permission denied) limiting the environment. Comment for now.

See-Also: https://github.com/containers/crun/issues/1388