### PR TITLE
FFI: add setsysctl

### DIFF
--- a/tests/e2e/tools/FFI/README.md
+++ b/tests/e2e/tools/FFI/README.md
@@ -14,3 +14,6 @@ Example:
 
 ## Disk
 Try to allocate as maximum possible disk space.
+
+## Sysctl
+Running as nested container inside QM attempt to change settings in the host level (ASIL).

--- a/tests/e2e/tools/FFI/sysctl/README
+++ b/tests/e2e/tools/FFI/sysctl/README
@@ -1,0 +1,21 @@
+# What is setsysctl?
+setsysctl is simple script that uses sysctl tool to try to change several parameters in the host OS.
+
+# How to use it?
+It must be executed inside QM environment as a container (nested) to make sure attemps to change OS level are denied.
+
+Example:
+```
+my-host# podman exec -it qm bash
+
+bash-5.1# podman run -it fedora bash
+
+[root@d0c4f92289b0 ~]# ./setsysctl
+Setting sysctl parameters...
+sysctl: permission denied on key "net.ipv4.ip_forward"
+sysctl: permission denied on key "net.ipv4.conf.all.rp_filter"
+sysctl: permission denied on key "net.ipv4.tcp_max_syn_backlog"
+sysctl: permission denied on key "vm.swappiness"
+sysctl: permission denied on key "vm.overcommit_memory"
+done
+```

--- a/tests/e2e/tools/FFI/sysctl/setsysctl
+++ b/tests/e2e/tools/FFI/sysctl/setsysctl
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+if ! command -v sysctl &>/dev/null; then
+    echo "sysctl tool is not installed. Installing..."
+    sudo dnf install -y procps-ng
+fi
+
+echo "Setting sysctl parameters..."
+
+# Generate a random number within a given range
+generate_random_number() {
+    local min=$1
+    local max=$2
+    echo $((RANDOM % (max - min + 1) + min))
+}
+
+# Network tuning parameters
+sysctl -w net.ipv4.ip_forward=$(generate_random_number 0 1)
+sysctl -w net.ipv4.conf.all.rp_filter=$(generate_random_number 0 2)
+sysctl -w net.ipv4.tcp_max_syn_backlog=$(generate_random_number 128 1024)
+
+# Buffer Sizes
+if [ -f "/proc/sys/net/core/rmem_max" ]; then
+    sysctl -w net.core.rmem_max=$(generate_random_number 4096 16777216)
+fi
+
+if [ -f "/proc/sys/net/core/wmem_max" ]; then
+    sysctl -w net.core.wmem_max=$(generate_random_number 4096 16777216)
+fi
+
+# Memory management settings
+sysctl -w vm.swappiness=$(generate_random_number 0 100)
+sysctl -w vm.overcommit_memory=$(generate_random_number 0 2)
+
+echo "done"


### PR DESCRIPTION
setsysctl is simple script that uses sysctl tool to try to change several parameters in the host OS.

It must be executed inside QM environment as a container (nested) to make sure attemps to change OS level are denied. Based in this tool, we can add it too the Container Image ffi-tools and generate tests.