### PR TITLE
seccomp: add new tool create-seccomp-rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,7 @@ install: man all
 	install -d -m 755 ${DESTDIR}${DATADIR}/qm
 	install -D -m 644 qm_contexts  ${DESTDIR}${DATADIR}/qm/contexts
 	install -D -m 755 setup ${DESTDIR}${DATADIR}/qm/setup
+	install -D -m 755 create-seccomp-rules ${DESTDIR}${DATADIR}/qm/create-seccomp-rules
 	install -D -m 644 qm_file_contexts ${DESTDIR}${DATADIR}/qm/file_contexts
 	install -D -m 644 containers.conf ${DESTDIR}${DATADIR}/qm/containers.conf
 	install -D -m 644 qm.container ${DESTDIR}${DATADIR}/containers/systemd/qm.container

--- a/create-seccomp-rules
+++ b/create-seccomp-rules
@@ -1,0 +1,76 @@
+#!/bin/bash
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+SECCOMP_CONTAINERS_FILE="/usr/share/containers/seccomp.json"
+QM_PATH_SECCOMP="/usr/share/qm/seccomp.json"
+QM_DIR="${QM_PATH_SECCOMP%/*}"
+
+function remove_seccomp_entry_from_allow() {
+    local syscall_name=$1
+    local seccomp_file_path=$2
+
+    # sponge is used to absorb the output of jq and then write it back to the
+    # original file safely.
+    jq --tab \
+        --arg syscall "$syscall_name" \
+	--arg action "$action_type" \
+        '(.syscalls[] | select(.names[] == $syscall and .action == "SCMP_ACT_ALLOW").names) |= map(select(. != $syscall))' \
+        "${seccomp_file_path}" | sponge "${seccomp_file_path}"
+    
+}
+
+function add_syscall_deny_list() {
+    local syscall_name="$1"
+    local seccomp_file_path="$2"
+
+    # sponge is used to absorb the output of jq and then write it back to the
+    # original file safely.
+    jq --tab \
+       --arg syscall "$syscall_name" \
+       --arg action "$action_type" \
+       '.syscalls += [{"names": [$syscall], "action": "SCMP_ACT_ERRNO", "args": [], "errnoRet": 1, "errno": "EPERM"}]' \
+       "${seccomp_file_path}" | sponge "${seccomp_file_path}"
+}
+
+# Main
+if [ ! -f "${SECCOMP_CONTAINERS_FILE}" ]; then
+    echo "Exiting... unable to find ${SECCOMP_CONTAINERS_FILE}"
+    exit 1
+fi
+
+if [ ! -d "${QM_DIR}" ]; then
+    echo "Exiting... unable to find ${QM_DIR}"
+    exit 1
+fi
+
+# Copying original seccomp.json
+cp "${SECCOMP_CONTAINERS_FILE}" "${QM_PATH_SECCOMP}"
+
+remove_seccomp_entry_from_allow \
+	"sched_setscheduler" \
+	"${QM_PATH_SECCOMP}"
+
+remove_seccomp_entry_from_allow \
+	"sched_setattr" \
+	"${QM_PATH_SECCOMP}"
+
+add_syscall_deny_list \
+	"sched_setscheduler" \
+	"${QM_PATH_SECCOMP}"
+
+add_syscall_deny_list \
+	"sched_setattr" \
+	"${QM_PATH_SECCOMP}"

--- a/rpm/qm.spec
+++ b/rpm/qm.spec
@@ -62,8 +62,10 @@ Requires(post): selinux-policy-base >= %_selinux_policy_version
 Requires(post): selinux-policy-targeted >= %_selinux_policy_version
 Requires(post): policycoreutils
 Requires(post): libselinux-utils
+Requires: moreutils
 Requires: podman >= %{podman_epoch}:4.5
 Requires: bluechi-agent
+Requires: jq
 
 %description
 This package allow users to setup an environment which prevents applications
@@ -95,6 +97,8 @@ sed -i 's/^install: man all/install:/' Makefile
 # Install all modules in a single transaction
 %_format MODULES %{_datadir}/selinux/packages/$x.pp.bz2
 %selinux_modules_install -s %{selinuxtype} $MODULES
+# Execute the script to create seccomp rules after the package is installed
+/usr/share/qm/create-seccomp-rules
 
 %postun
 if [ $1 -eq 0 ]; then
@@ -114,6 +118,7 @@ fi
 %{_datadir}/qm/contexts
 %{_datadir}/qm/file_contexts
 %{_datadir}/qm/setup
+%{_datadir}/qm/create-seccomp-rules
 %ghost %dir %{_datadir}/containers
 %ghost %dir %{_datadir}/containers/systemd
 %{_datadir}/containers/systemd/qm.container

--- a/setup
+++ b/setup
@@ -142,34 +142,6 @@ create_rootfs_required_dirs() {
 
 }
 
-create_qm_seccomp_rules() {
-    TEMP_SECCOMP=$(mktemp)
-    SECCOMP_FILE_PATH="/usr/share/containers/seccomp.json"
-    QM_PATH_SECCOMP="/usr/share/qm/seccomp.json"
-
-    if [ ! -f "${SECCOMP_FILE_PATH}" ]; then
-        rm -f "${TEMP_SECCOMP}"
-        echo "Exiting... unable to find ${SECCOMP_FILE_PATH}"
-        exit 1
-    fi
-
-    # Copying original seccomp.json
-    cp "${SECCOMP_FILE_PATH}" "${QM_PATH_SECCOMP}"
-
-    # seccomp.json can be updated, we should get it from the source and adapt it.
-    echo "- Removing sched_setscheduler() as allowed syscall"
-    # make sure create a fresh seccomp.json for QM and remove allow permission for sched_setscheduler() syscall
-    jq --tab '(.syscalls[] | select(.names[] == "sched_setscheduler" and .action == "SCMP_ACT_ALLOW") .names) |= map(select(. != "sched_setscheduler"))' "${SECCOMP_FILE_PATH}" > "${TEMP_SECCOMP}"
-
-    echo "- Adding sched_setscheduler() into the deny list"
-    # Add sched_setscheduler to the deny list
-    jq --tab '.syscalls += [{"names": ["sched_setscheduler"], "action": "SCMP_ACT_ERRNO", "args": [], "errnoRet": 1, "errno": "EPERM"}]' "${TEMP_SECCOMP}" > "${QM_PATH_SECCOMP}"
-
-    rm -f "${TEMP_SECCOMP}"
-    echo -e "\ndone"
-
-}
-
 validate_qm_installation() {
     files=(
         "${INSTALLDIR}/containers.conf"
@@ -247,9 +219,6 @@ eval set --"${opts}"
 
 # main()
 root_check
-
-# Create a QM seccomp.json before start the QM daemon
-create_qm_seccomp_rules
 
 while [[ $# -gt 0 ]]; do
   case "$1" in


### PR DESCRIPTION
This patch removes the logic from setup and creates a independent tool to manage seccomp rules for QM. It should help with ostree issue.

Fixes: https://github.com/containers/qm/issues/385
Fixes: https://github.com/containers/qm/issues/375