### PR TITLE
qm.container: replace Timezone=local

### DIFF
--- a/qm.container
+++ b/qm.container
@@ -38,6 +38,11 @@ SecurityLabelNested=true
 SecurityLabelFileType=qm_file_t
 SecurityLabelLevel=s0
 SecurityLabelType=qm_t
-Timezone=local
+
+# ostree based distro use Env=TZ
+# See GH#367 for more info
+# Timezone=local
+Environment=TZ
+
 Volume=${RWETCFS}:/etc
 Volume=${RWVARFS}:/var


### PR DESCRIPTION
In recent tests with ostree + quadlet environment the QM service was not able to work correctly, podman failed to remove /etc/localtime affecting the QM service. This patch is a workaround to Timezone=local which uses Environment=TZ to set the default timezone to UTC until we work in root cause.

More information: https://github.com/containers/qm/issues/367

Fixes: https://github.com/containers/qm/issues/367