### PR TITLE
qm.container: replace tz=local in ostree distro

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,7 @@ install: man all
 	install -d -m 755 ${DESTDIR}${DATADIR}/qm
 	install -D -m 644 qm_contexts  ${DESTDIR}${DATADIR}/qm/contexts
 	install -D -m 755 setup ${DESTDIR}${DATADIR}/qm/setup
+	install -D -m 755 tools/comment-tz-local ${DESTDIR}${DATADIR}/qm/comment-tz-local
 	install -D -m 755 create-seccomp-rules ${DESTDIR}${DATADIR}/qm/create-seccomp-rules
 	install -D -m 644 qm_file_contexts ${DESTDIR}${DATADIR}/qm/file_contexts
 	install -D -m 644 containers.conf ${DESTDIR}${DATADIR}/qm/containers.conf

--- a/rpm/qm.spec
+++ b/rpm/qm.spec
@@ -99,6 +99,7 @@ sed -i 's/^install: man all/install:/' Makefile
 %selinux_modules_install -s %{selinuxtype} $MODULES
 # Execute the script to create seccomp rules after the package is installed
 /usr/share/qm/create-seccomp-rules
+/usr/share/qm/comment-tz-local # FIX-ME GH-issue: 367
 
 %postun
 if [ $1 -eq 0 ]; then
@@ -119,6 +120,7 @@ fi
 %{_datadir}/qm/file_contexts
 %{_datadir}/qm/setup
 %{_datadir}/qm/create-seccomp-rules
+%{_datadir}/qm/comment-tz-local
 %ghost %dir %{_datadir}/containers
 %ghost %dir %{_datadir}/containers/systemd
 %{_datadir}/containers/systemd/qm.container

--- a/tools/comment-tz-local
+++ b/tools/comment-tz-local
@@ -1,0 +1,32 @@
+#!/bin/bash
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+# This tools is a workaround regarding the issue found in ostree image only
+# report via GitHub: https://github.com/containers/qm/issues/367
+
+# Path to the qm.container
+FILE="/usr/share/containers/systemd/qm.container"
+
+# Check for the presence of the string and if "Timezone=local" is already commented
+if ! grep -q "# WIP - Github Issue#367" "$FILE" && ! grep -q "# Timezone=local" "$FILE"; then
+    # Make changes if the strings do not exist
+    sed -i '/Timezone=local/ {
+        i # WIP - Github Issue#367
+        i # See https://github.com/containers/qm/issues/367 for more info.
+        s/^Timezone=local/# &/; # Comments the line that matches Timezone=local
+        a Environment=TZ
+    }' "$FILE"
+fi


### PR DESCRIPTION
In recent tests with ostree + quadlet environment the QM service was not able to work correctly, podman failed to remove /etc/localtime affecting the QM service. This patch is a workaround to Timezone=local which uses Environment=TZ to set the default timezone to UTC until we work in root cause.

More information: #367

Fixes: #367