### PR TITLE
setup: add validation for removing PACKAGES_TO_REMOVE

### DIFF
--- a/setup
+++ b/setup
@@ -168,8 +168,10 @@ install() {
     cmd_dnf_install="dnf -y install --releasever=${VERSION_ID} --installroot ${ROOTFS} ${PACKAGES_TO_INSTALL}"
     ${cmd_dnf_install}
 
-    cmd_dnf_remove="dnf --installroot ${ROOTFS} remove ${PACKAGES_TO_REMOVE} -y"
-    ${cmd_dnf_remove}
+    if dnf --installroot "${ROOTFS}" list installed "${PACKAGE_TO_REMOVE}" > /dev/null 2>&1; then
+        dnf --installroot ${ROOTFS} remove ${PACKAGES_TO_REMOVE} -y
+    fi
+
     # check if "${ROOTFS}"/etc/yum.repos.d
     if [ -z "$(find "${ROOTFS}"/etc/yum.repos.d -mindepth 1 -maxdepth 1)" ]; then
        cat > "${ROOTFS}/etc/yum.repos.d/autosd.repo" << EOF


### PR DESCRIPTION
We should validate if the packages exists to avoid exit in failed command.

Fixes: https://github.com/containers/qm/issues/396