### PR TITLE
ffi: Adding qm-omm-score-adj test

### DIFF
--- a/tests/ffi/qm-oom-score-adj/main.fmf
+++ b/tests/ffi/qm-oom-score-adj/main.fmf
@@ -1,0 +1,6 @@
+summary: Test the qm's oom-score-adj values
+test: /bin/bash ./test.sh
+duration: 10m
+tag: ffi
+framework: shell
+id: 6e6c5cea-efc7-48e9-8b4c-d355229ab1c2

--- a/tests/ffi/qm-oom-score-adj/test.sh
+++ b/tests/ffi/qm-oom-score-adj/test.sh
@@ -1,0 +1,41 @@
+#!/bin/bash -euvx
+
+# shellcheck disable=SC1091
+
+. ../common/prepare.sh
+
+export QM_HOST_REGISTRY_DIR="/var/qm/lib/containers/registry"
+export QM_REGISTRY_DIR="/var/lib/containers/registry"
+
+disk_cleanup
+prepare_test
+reload_config
+
+# Copy container image registry to /var/qm/lib/containers
+image_id=$(podman images | grep quay.io/centos-sig-automotive/ffi-tools | awk -F " " '{print $3}')
+if [ ! -d "${QM_HOST_REGISTRY_DIR}" ]; then
+    exec_cmd "mkdir -p ${QM_HOST_REGISTRY_DIR}"
+    exec_cmd "podman push ${image_id} dir:${QM_HOST_REGISTRY_DIR}/tools-ffi:latest"
+fi
+
+podman exec -it qm /bin/bash -c \
+         "podman run -d --replace --name ffi-qm  dir:${QM_REGISTRY_DIR}/tools-ffi:latest \
+          /usr/bin/sleep infinity > /dev/null"
+
+
+QM_PID=$(podman inspect qm --format '{{.State.Pid}}' | tr -d '\r')
+QM_FFI_PID=$(podman exec -it qm /bin/bash -c "podman inspect ffi-qm --format '{{.State.Pid}}'" | tr -d '\r')
+
+QM_OOM_SCORE_ADJ=$(cat /proc/$QM_PID/oom_score_adj)
+QM_FFI_OOM_SCORE_ADJ=$(podman exec -it qm /bin/bash -c "cat /proc/$QM_FFI_PID/oom_score_adj" | tr -d '\r')
+
+
+# "500" is the oom_score_adj defined for the qm/qm.container.
+test "$QM_OOM_SCORE_ADJ" -eq "500"
+
+# "750" is the oom_score_adj defined in the qm/containers.conf as default value
+# for the containers that would run inside of the qm container.
+test "$QM_FFI_OOM_SCORE_ADJ" -eq "750"
+
+podman exec -it qm /bin/bash -c "podman stop ffi-qm > /dev/null"
+


### PR DESCRIPTION
Adding a ffi test to validate that que qm container main process runs with oom_score_adj = 500 and the qm containers processes runs with the om_score_adj = 750 by default

resolve #427 