### PR TITLE
ffi: Adding modprobe modules case.

### DIFF
--- a/tests/ffi/modules/main.fmf
+++ b/tests/ffi/modules/main.fmf
@@ -1,0 +1,6 @@
+summary: modprobe - test interference from the QM partition to host
+test: /bin/bash ./test.sh
+duration: 20m
+tag: ffi
+framework: shell
+id: 74275f94-c9a4-45f3-8e46-86a904f26959

--- a/tests/ffi/modules/test.sh
+++ b/tests/ffi/modules/test.sh
@@ -1,0 +1,32 @@
+#!/bin/bash -euvx
+
+# shellcheck disable=SC1091
+
+. ../common/prepare.sh
+
+export QM_HOST_REGISTRY_DIR="/var/qm/lib/containers/registry"
+export QM_REGISTRY_DIR="/var/lib/containers/registry"
+
+disk_cleanup
+prepare_test
+reload_config
+
+# Download ffi-tools container and push ffi-tools image into QM registry
+prepare_images
+
+# Run the ffi-tools container in qm vm
+run_container_in_qm ffi-qm
+
+# Get result message of './modprobe_module'
+msg=$(podman exec -it qm /bin/bash -c \
+               "podman exec ffi-qm ./modprobe_module 2>&1")
+
+# Check result message displays right.
+if grep -eq "modprobe: FATAL: Module ext4 not found in directory /lib/modules/*" "$msg"; then
+   if_error_exit "Module ext4 should not found in /lib/modules/ inside QM"
+elif grep -Eq "ls: cannot access '(.+)': No such file or directory" "$msg"; then
+   if_error_exit "Modules address under /lib/modules/ cannot access inside QM"
+else
+   info_message "Access /lib/modules to load any module via modprobe is impossible inside QM container"
+   exit 0
+fi


### PR DESCRIPTION
Adding a ffi test to check it won't be possible to access /lib/modules to load any module via modprobe inside the QM partition.
resolve #373 

Make sure it won't be possible to access /lib/modules to load any module via modprobe inside QM container, like below:
```
bash-5.1# modprobe ext4
modprobe: FATAL: Module ext4 not found in directory /lib/modules/5.14.0-438.391.el9iv.x86_64
bash-5.1# ls /lib/modules/5.14.0-438.391.el9iv.x86_64
ls: cannot access '/lib/modules/5.14.0-438.391.el9iv.x86_64': No such file or directory
``` 