### PR TITLE
add execute_sched_setattr

### DIFF
--- a/tests/e2e/tools/FFI/Makefile
+++ b/tests/e2e/tools/FFI/Makefile
@@ -1,13 +1,13 @@
 CC = gcc
 CFLAGS = -Wall -g
 
-VPATH=disk/QM:memory:deny_set_scheduler
+VPATH=disk/QM:memory:deny_set_scheduler:deny_sched_setattr
 QM_BIN=./bin/QM
 ASIL_BIN=./bin/ASIL
 
 all: cratetestqm cratetestasil
 
-cratetestqm: createqmbin file-allocate 90_percent_memory_eat test_sched_setscheduler
+cratetestqm: createqmbin file-allocate 90_percent_memory_eat test_sched_setscheduler execute_sched_setattr
 
 cratetestasil: createasilbin 20_percent_memory_eat
 
@@ -27,6 +27,9 @@ file-allocate: file-allocate.c
 	$(CC) $(CFLAGS) -DMEM_PERCENT=0.9 -o $(QM_BIN)/$@ $<
 
 test_sched_setscheduler: execute_set_scheduler.c
+	$(CC) $(CFLAGS) -o $(QM_BIN)/$@ $<
+
+execute_sched_setattr: execute_sched_setattr.c
 	$(CC) $(CFLAGS) -o $(QM_BIN)/$@ $<
 
 clean:


### PR DESCRIPTION
 updated the `makefile` to add the tool `execute_sched_setattr` according to https://github.com/containers/qm/issues/377
