### PR TITLE
add deny_sched_setattr

### DIFF
--- a/tests/ffi/deny_sched_setattr/main.fmf
+++ b/tests/ffi/deny_sched_setattr/main.fmf
@@ -1,6 +1,6 @@
-summary: Test QM not allow SCHED_DEADLINE be set via sched_setattr() syscall  
+summary: Test QM not allow SCHED_DEADLINE be set via sched_setattr() syscall
 test: /bin/bash ./test.sh
 duration: 10m
 tag: ffi
 framework: shell
-
+id: 6e0d8dd9-2106-4f57-be1b-98f443145b36

--- a/tests/ffi/deny_sched_setattr/main.fmf
+++ b/tests/ffi/deny_sched_setattr/main.fmf
@@ -1,0 +1,6 @@
+summary: Test QM not allow SCHED_DEADLINE be set via sched_setattr() syscall  
+test: /bin/bash ./test.sh
+duration: 10m
+tag: ffi
+framework: shell
+

--- a/tests/ffi/deny_sched_setattr/test.sh
+++ b/tests/ffi/deny_sched_setattr/test.sh
@@ -19,6 +19,6 @@ return_from_sched_setattr=$(podman exec -it qm /bin/bash -c \
 if [[ "${return_from_sched_setattr}" =~ "${expected_result}" ]]; then
     info_message "QM not allow SCHED_DEADLINE be set via sched_setattr() syscall."
 else
-    info_message "SCHED_DEADLINE can be set via sched_setattr() syscall in QM."
+    info_message "Failure: SCHED_DEADLINE can not be set via sched_setattr() syscall in QM."
     exit 1
 fi

--- a/tests/ffi/deny_sched_setattr/test.sh
+++ b/tests/ffi/deny_sched_setattr/test.sh
@@ -1,0 +1,24 @@
+#!/bin/bash -euvx
+
+. ../common/prepare.sh
+
+export QM_HOST_REGISTRY_DIR="/var/qm/lib/containers/registry"
+export QM_REGISTRY_DIR="/var/lib/containers/registry"
+expected_result="sched_setattr failed: Operation not permitted"
+
+disk_cleanup
+prepare_test
+reload_config
+
+prepare_images
+run_container_in_qm "ffi-qm"
+
+return_from_sched_setattr=$(podman exec -it qm /bin/bash -c \
+         'podman exec -it ffi-qm ./QM/execute_sched_setattr')
+
+if [[ "${return_from_sched_setattr}" =~ "${expected_result}" ]]; then
+    info_message "QM not allow SCHED_DEADLINE be set via sched_setattr() syscall."
+else
+    info_message "SCHED_DEADLINE can be set via sched_setattr() syscall in QM."
+    exit 1
+fi


### PR DESCRIPTION
Add tmt test case for tool "execute_sched_setattr" to verify that QM environment not allow SCHED_DEADLINE be set via sched_setattr() syscall
resolve https://github.com/containers/qm/issues/377