### PR TITLE
tools: generate-release-notes

### DIFF
--- a/tools/generate-release-notes
+++ b/tools/generate-release-notes
@@ -1,0 +1,131 @@
+#!/bin/bash
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+UPSTREAM_URL="https://github.com/containers/qm"
+
+show_tags() {
+  echo "Fetching all tags from $UPSTREAM_URL..."
+  git remote add upstream "$UPSTREAM_URL" &> /dev/null
+  git fetch upstream --tags &> /dev/null
+  echo "Available tags:"
+  git tag -l
+}
+
+# Ensure two tags are provided or --show-tags is used
+if [ "$#" -eq 1 ] && [ "$1" == "--show-tags" ]; then
+  show_tags
+  exit 0
+elif [ "$#" -eq 2 ] || [ "$#" -eq 3 ]; then
+  if [ "$#" -eq 3 ]; then
+    UPSTREAM_URL=$3
+  fi
+else
+  echo "Usage: $0 <older-tag> <newer-tag> [upstream-url]"
+  echo "       $0 --show-tags [upstream-url]"
+  echo "Example: $0 v0.6.2 v0.6.3"
+  echo "Example with custom upstream to download tags: $0 v0.6.2 v0.6.3 https://github.com/custom/repo"
+  exit 1
+fi
+
+OLDER_TAG=$1
+NEWER_TAG=$2
+
+# Print starting message
+echo "Generating release notes from $OLDER_TAG to $NEWER_TAG..."
+
+# Fetch all tags
+echo "Collecting tags from $UPSTREAM_URL..."
+git remote add upstream "$UPSTREAM_URL" &> /dev/null
+git fetch upstream --tags &> /dev/null
+
+# Check if tags exist
+echo "Checking if tags exist..."
+if ! git rev-parse "$OLDER_TAG" >/dev/null 2>&1; then
+  echo "Error: Tag '$OLDER_TAG' does not exist."
+  exit 1
+fi
+
+if ! git rev-parse "$NEWER_TAG" >/dev/null 2>&1; then
+  echo "Error: Tag '$NEWER_TAG' does not exist."
+  exit 1
+fi
+
+# Get the log between the two tags
+echo "Fetching commit logs..."
+LOG=$(git log --pretty=format:"- %s (%an, %ad)" "$OLDER_TAG".."$NEWER_TAG")
+
+# Categorize logs into sections
+echo "Categorizing commits..."
+NEW_FEATURES=""
+BUG_FIXES=""
+TESTING=""
+DOCS=""
+new_count=0
+bug_fixes_count=0
+testing_count=0
+docs_count=0
+
+while IFS= read -r line; do
+  if [[ "$line" =~ ^-?[[:space:]]*(Add|add|New|new|Initial|initial|RFE|tools: add|seccomp: add|FFI: add) ]]; then
+    NEW_FEATURES+="$line\n"
+    ((new_count++))
+  elif [[ "$line" =~ ^-?[[:space:]]*(Fix|fix|Bug|bug|Remove|remove|spec:|qm.container:|prepare.sh:|setup:|qm:|Merge|use|qm.containers:|seccomp|FFI|revert) ]]; then
+    BUG_FIXES+="$line\n"
+    ((bug_fixes_count++))
+  elif [[ "$line" =~ ^-?[[:space:]]*(Test|test|Testing|testing|main.fmf:|tests:|packit:) ]]; then
+    TESTING+="$line\n"
+    ((testing_count++))
+  elif [[ "$line" =~ ^-?[[:space:]]*(Doc|doc|README|readme|Docs|docs) ]]; then
+    DOCS+="$line\n"
+    ((docs_count++))
+  fi
+done <<< "$LOG"
+
+total_count=$((new_count + bug_fixes_count + testing_count + docs_count))
+
+# Refine the wording in the sections
+if [ -n "$NEW_FEATURES" ]; then
+  NEW_FEATURES="New ($new_count):\n\n${NEW_FEATURES}"
+fi
+
+if [ -n "$BUG_FIXES" ]; then
+  BUG_FIXES="Bug-Fixes ($bug_fixes_count):\n\n${BUG_FIXES}"
+fi
+
+if [ -n "$TESTING" ]; then
+  TESTING="Testing ($testing_count):\n\n${TESTING}"
+fi
+
+if [ -n "$DOCS" ]; then
+  DOCS="Docs ($docs_count):\n\n${DOCS}"
+fi
+
+# Generate markdown output
+echo "Generating markdown output..."
+OUTPUT="What's new:
+==================
+
+${NEW_FEATURES}
+${BUG_FIXES}
+${TESTING}
+${DOCS}
+
+Total: $total_count
+"
+
+# Print the output
+echo -e "$OUTPUT"
+
+echo "Release notes generated successfully."
+


### PR DESCRIPTION
A tool to generate release notes.  Anyone interested (Release Docs Team, PM, Developers or Owners of Projects)  can generate the release notes locally and do not depend on GitHub UI. 

```
# git clone https://github.com/containers/qm
# cd qm/tools
#  ./generate-release-notes v0.6.2 v0.6.4
Generating release notes from v0.6.2 to v0.6.4...
Collecting tags from https://github.com/containers/qm...
Checking if tags exist...
Fetching commit logs...
Categorizing commits...
Generating markdown output...
What's new:
==================

New (11):

- tools: add qm-storage-settings (Douglas Schilling Landgraf, Fri May 3 00:27:57 2024 -0400)
- Add initial policy type for wayland (Daniel J Walsh, Wed Apr 24 14:17:04 2024 -0400)
- seccomp: add new tool create-seccomp-rules (Douglas Schilling Landgraf, Wed Apr 24 23:45:39 2024 -0400)
- tools: add deny_sched_setattr (Douglas Schilling Landgraf, Tue Apr 23 20:24:57 2024 -0400)
- FFI: add tool test for execute_set_scheduler.c (Douglas Schilling Landgraf, Thu Apr 18 10:44:27 2024 -0400)
- FFI: add setsysctl (Douglas Schilling Landgraf, Wed Apr 17 23:10:48 2024 -0400)
- add shm to ffi tools (pengshanyu, Fri Mar 15 10:21:19 2024 +0800)
- add autosd repo for c9s (pengshanyu, Tue Mar 12 14:35:31 2024 +0800)
- Adding test ids to already existing testsA .fmf files reformatted (Pavol Brilla, Fri Feb 16 11:08:04 2024 +0100)
- Adding ROOTFS repo dir check (Yariv Rachmani, Sun Jan 28 21:01:57 2024 +0200)
- Adding fixes base on QC SoC (Yariv Rachmani, Tue Jan 16 13:40:41 2024 +0200)

Bug-Fixes (22):

- spec: remove the need of moreutils (Douglas Schilling Landgraf, Sun May 12 23:41:34 2024 -0400)
- seccomp: use SYSCALLS_TO_DENY array (Douglas Schilling Landgraf, Wed May 1 11:53:06 2024 -0400)
- qm.container: change default network option (Douglas Schilling Landgraf, Tue Apr 30 09:56:47 2024 -0400)
- qm: make sure remove rootfs when uninstalling (Douglas Schilling Landgraf, Sun Apr 28 11:49:06 2024 -0400)
- prepare.sh: remove FIX-ME regarding restorecon (Douglas Schilling Landgraf, Fri Apr 26 23:40:57 2024 -0400)
- spec: make sure remove speccomp.json (Douglas Schilling Landgraf, Sat Apr 27 10:28:31 2024 -0400)
- setup: add validation for removing PACKAGES_TO_REMOVE (Douglas Schilling Landgraf, Sat Apr 27 00:53:22 2024 -0400)
- qm.container: replace tz=local in ostree distro (Douglas Schilling Landgraf, Fri Apr 26 11:01:07 2024 -0400)
- spec: remove validation for podman package (Douglas Schilling Landgraf, Wed Apr 24 11:32:29 2024 -0400)
- setup: validate qm installation (Douglas Schilling Landgraf, Thu Apr 18 18:32:44 2024 -0400)
- qm: add seccomp json also deny sched_setscheduler (Douglas Schilling Landgraf, Tue Apr 9 18:35:21 2024 -0400)
- qm: add back readonlytmp (Douglas Schilling Landgraf, Mon Apr 8 14:44:29 2024 -0400)
- qm.container: add back SecurityLabelNested=True (Douglas Schilling Landgraf, Mon Apr 8 14:21:56 2024 -0400)
- revert to before adding shm (pengshanyu, Wed Mar 27 11:41:01 2024 +0800)
- Merge pull request #352 from pengshanyu/remove-shm-source-code (Yariv Rachmani, Tue Mar 26 12:41:44 2024 +0200)
- remove shm souce code (pengshanyu, Tue Mar 26 11:19:45 2024 +0800)
- Merge pull request #349 from pengshanyu/add-shm-to-ffi-tools (Yariv Rachmani, Mon Mar 18 12:54:17 2024 +0200)
- Merge pull request #347 from pengshanyu/add_autosd_repo_for_c9s (Yariv Rachmani, Wed Mar 13 14:18:11 2024 +0200)
- use template code to install autosd repo;optimize if else;add info message (pengshanyu, Wed Mar 13 13:18:27 2024 +0800)
- Fixes related to arm64 (Yariv Rachmani, Tue Jan 30 21:08:43 2024 +0200)
- qm.containers: uncomment DropCapability (Douglas Schilling Landgraf, Tue Jan 30 09:30:34 2024 -0500)
- Merge pull request #332 from Yarboa/SoC-test-cont (Yariv Rachmani, Mon Jan 29 22:30:38 2024 +0200)

Testing (6):

- main.fmf: agent.flood add test: back (Douglas Schilling Landgraf, Sun May 12 23:20:41 2024 -0400)
- tests: skip agent-flood test (Douglas Schilling Landgraf, Sun May 12 23:04:11 2024 -0400)
- packit: add fedora40 to the list (Douglas Schilling Landgraf, Sat May 4 08:51:30 2024 -0400)
- tests: rename README to README.md (Douglas Schilling Landgraf, Wed May 1 09:14:16 2024 -0400)
- tests: remove fix-me regarding oom killer (Douglas Schilling Landgraf, Wed Apr 10 09:52:12 2024 -0400)
- tests: fix summary agent-flood/main.fmf (Douglas Schilling Landgraf, Thu Feb 22 13:32:02 2024 -0500)

Docs (7):

- docs: devel - add process of copying files to QM (Douglas Schilling Landgraf, Tue May 7 01:38:46 2024 -0400)
- docs: how to install/remove software in QM (Douglas Schilling Landgraf, Tue May 7 01:27:00 2024 -0400)
- doc: add more items to TOC (useful commands) (Douglas Schilling Landgraf, Tue May 7 01:13:52 2024 -0400)
- docs: Add more info to devel README (Douglas Schilling Landgraf, Wed May 1 10:45:51 2024 -0400)
- docs: README add RPM mirror info (Douglas Schilling Landgraf, Tue Apr 30 11:32:41 2024 -0400)
- docs: Add devel README (Douglas Schilling Landgraf, Sun Apr 28 17:46:31 2024 -0400)
- README: add some commands for selinux help (Douglas Schilling Landgraf, Sat Apr 27 11:27:27 2024 -0400)


Total: 46

Release notes generated successfully.
```