### PR TITLE
test stability changes

### DIFF
--- a/tests/e2e/lib/container
+++ b/tests/e2e/lib/container
@@ -62,6 +62,7 @@ file: ${container_file} tag: ${container_tag}"
     # Execute the container
     eval "$(podman run -d \
                 --privileged \
+                --tz local \
                 --network podmanDualStack \
                 --name "${container_name}" \
                 --hostname "${container_name}" \

--- a/tests/ffi/deny_sched_setattr/test.sh
+++ b/tests/ffi/deny_sched_setattr/test.sh
@@ -3,8 +3,6 @@
 # shellcheck source=tests/ffi/common/prepare.sh
 . ../common/prepare.sh
 
-export QM_HOST_REGISTRY_DIR="/var/qm/lib/containers/registry"
-export QM_REGISTRY_DIR="/var/lib/containers/registry"
 expected_result="sched_setattr failed: Operation not permitted"
 
 disk_cleanup

--- a/tests/ffi/deny_set_scheduler/test.sh
+++ b/tests/ffi/deny_set_scheduler/test.sh
@@ -3,8 +3,6 @@
 # shellcheck source=tests/ffi/common/prepare.sh
 . ../common/prepare.sh
 
-export QM_HOST_REGISTRY_DIR="/var/qm/lib/containers/registry"
-export QM_REGISTRY_DIR="/var/lib/containers/registry"
 expected_result="Failed to set scheduler: Operation not permitted"
 
 disk_cleanup

--- a/tests/ffi/disk/test.sh
+++ b/tests/ffi/disk/test.sh
@@ -7,12 +7,14 @@
 disk_cleanup
 prepare_test
 
-cat << EOF > /etc/containers/systemd/qm.container.d/oom.conf
+cat << EOF > "${DROP_IN_DIR}"/oom.conf
 [Service]
+OOMScoreAdjust=
 OOMScoreAdjust=1000
 EOF
 
 reload_config
+prepare_images
 
 exec_cmd "podman exec -it qm /bin/bash -c \
          'podman run -d  --replace --name ffi-qm \

--- a/tests/ffi/memory/main.fmf
+++ b/tests/ffi/memory/main.fmf
@@ -1,6 +1,6 @@
 summary: Test is calling systemd as stand alone test
 test: /bin/bash ./test.sh
-duration: 10m
+duration: 15m
 tag: ffi
 framework: shell
 id: fff26f33-a051-4d9e-aae2-97935e425273

--- a/tests/ffi/memory/test.sh
+++ b/tests/ffi/memory/test.sh
@@ -4,22 +4,21 @@
 
 . ../common/prepare.sh
 
-export QM_HOST_REGISTRY_DIR="/var/qm/lib/containers/registry"
-export QM_REGISTRY_DIR="/var/lib/containers/registry"
-
 disk_cleanup
 prepare_test
+
+cat << EOF > "${DROP_IN_DIR}"/oom.conf
+[Service]
+OOMScoreAdjust=
+OOMScoreAdjust=1000
+EOF
+
 reload_config
+prepare_images
 
 exec_cmd "podman run -d --rm --replace -d --name ffi-asil \
           quay.io/centos-sig-automotive/ffi-tools:latest \
           ./ASIL/20_percent_memory_eat > /dev/null"
-# Copy container image registry to /var/qm/lib/containers
-image_id=$(podman images | grep quay.io/centos-sig-automotive/ffi-tools | awk -F " " '{print $3}')
-if [ ! -d "${QM_HOST_REGISTRY_DIR}" ]; then
-    exec_cmd "mkdir -p ${QM_HOST_REGISTRY_DIR}"
-    exec_cmd "podman push ${image_id} dir:${QM_HOST_REGISTRY_DIR}/tools-ffi:latest"
-fi
 
 podman exec -it qm /bin/bash -c \
          "podman run  --replace --name ffi-qm  dir:${QM_REGISTRY_DIR}/tools-ffi:latest \

--- a/tests/ffi/modules/test.sh
+++ b/tests/ffi/modules/test.sh
@@ -4,9 +4,6 @@
 
 . ../common/prepare.sh
 
-export QM_HOST_REGISTRY_DIR="/var/qm/lib/containers/registry"
-export QM_REGISTRY_DIR="/var/lib/containers/registry"
-
 disk_cleanup
 prepare_test
 reload_config

--- a/tests/ffi/qm-oom-score-adj/test.sh
+++ b/tests/ffi/qm-oom-score-adj/test.sh
@@ -4,19 +4,9 @@
 
 . ../common/prepare.sh
 
-export QM_HOST_REGISTRY_DIR="/var/qm/lib/containers/registry"
-export QM_REGISTRY_DIR="/var/lib/containers/registry"
-
 disk_cleanup
-prepare_test
+prepare_images
 reload_config
-
-# Copy container image registry to /var/qm/lib/containers
-image_id=$(podman images | grep quay.io/centos-sig-automotive/ffi-tools | awk -F " " '{print $3}')
-if [ ! -d "${QM_HOST_REGISTRY_DIR}" ]; then
-    exec_cmd "mkdir -p ${QM_HOST_REGISTRY_DIR}"
-    exec_cmd "podman push ${image_id} dir:${QM_HOST_REGISTRY_DIR}/tools-ffi:latest"
-fi
 
 podman exec -it qm /bin/bash -c \
          "podman run -d --replace --name ffi-qm  dir:${QM_REGISTRY_DIR}/tools-ffi:latest \

--- a/tests/ffi/sysctl/test.sh
+++ b/tests/ffi/sysctl/test.sh
@@ -4,9 +4,6 @@
 
 . ../common/prepare.sh
 
-export QM_HOST_REGISTRY_DIR="/var/qm/lib/containers/registry"
-export QM_REGISTRY_DIR="/var/lib/containers/registry"
-
 disk_cleanup
 prepare_test
 reload_config


### PR DESCRIPTION
TZ update to sync tier-0 testing

remove containers host containers from disk on cleanup
Remove qm.service update referencing to usage of drop-in files
    
fixes #451, fixes #462, fixes  #473

Signed-off-by: Yariv Rachmani <yrachman@redhat.com>
