### PR TITLE
qm.if: allow stream connect for qm_container_ipc_t

### DIFF
--- a/qm.if
+++ b/qm.if
@@ -327,6 +327,7 @@ template(`qm_domain_template',`
 	domain_user_exemption_target($1_container_ipc_t)
 	container_manage_files_template($1_container_ipc, $1_container)
 	container_ipc_stream_connect($1_container_ipc_t)
+	container_stream_connect($1_container_ipc_t)
 
 	type $1_container_file_t, $1_file_type;
 	files_type($1_container_file_t)


### PR DESCRIPTION
Solve a connectto issue with ipc socket by calling `container_stream_connect` macro for the
`qm_container_ipc_t` label.

Closes: https://github.com/containers/qm/issues/468