### PR TITLE
tests: Disable oom_score_adj on prepare_test

### DIFF
--- a/tests/ffi/common/prepare.sh
+++ b/tests/ffi/common/prepare.sh
@@ -12,6 +12,8 @@ prepare_test() {
    exec_cmd "sed -i 's|DropCapability=sys_resource|#DropCapability=sys_resource|' \
             ${qm_service_file}"
    exec_cmd "restorecon -RFv /var/lib/containers"
+   # Create qm container custom config folder
+   exec_cmd "mkdir -p /etc/containers/systemd/qm.container.d"
    # FIXME: This action should be performed if necessary through systemd drop-in files.
    #
    # # Changing QM score to 1000 to avoid full memory error on SoC
@@ -24,6 +26,8 @@ disk_cleanup() {
    exec_cmd "systemctl stop qm"
    remove_file=$(find /var/qm -size  +2G)
    exec_cmd "rm -f $remove_file"
+   remove_qm_custom_conf_files=$(find /etc/containers/systemd/qm.container.d -type f)
+   exec_cmd "rm -f $remove_qm_custom_conf_files"
    exec_cmd "systemctl start qm"
    remove_file=$(find /root -size  +1G)
    exec_cmd "rm -f $remove_file"

--- a/tests/ffi/common/prepare.sh
+++ b/tests/ffi/common/prepare.sh
@@ -12,10 +12,12 @@ prepare_test() {
    exec_cmd "sed -i 's|DropCapability=sys_resource|#DropCapability=sys_resource|' \
             ${qm_service_file}"
    exec_cmd "restorecon -RFv /var/lib/containers"
-   # Changing QM score to 1000 to avoid full memory error on SoC
-   if [[ -n "${PACKIT_COPR_PROJECT}" && "${PACKIT_COPR_PROJECT}" == "release" ]]; then
-     exec_cmd "sed -i 's|OOMScoreAdjust.*|OOMScoreAdjust=1000|' ${qm_service_file}"
-   fi
+   # FIXME: This action should be performed if necessary through systemd drop-in files.
+   #
+   # # Changing QM score to 1000 to avoid full memory error on SoC
+   # if [[ -n "${PACKIT_COPR_PROJECT}" && "${PACKIT_COPR_PROJECT}" == "release" ]]; then
+   #   exec_cmd "sed -i 's|OOMScoreAdjust.*|OOMScoreAdjust=1000|' ${qm_service_file}"
+   # fi
 }
 
 disk_cleanup() {

--- a/tests/ffi/disk/test.sh
+++ b/tests/ffi/disk/test.sh
@@ -6,6 +6,12 @@
 
 disk_cleanup
 prepare_test
+
+cat << EOF > /etc/containers/systemd/qm.container.d/oom.conf
+[Service]
+OOMScoreAdjust=1000
+EOF
+
 reload_config
 
 exec_cmd "podman exec -it qm /bin/bash -c \


### PR DESCRIPTION
The prepare_test fuction overrides the OOMScoreAdjust value. That should be performed if necessary through systemd drop-in files.