### PR TITLE
Fix again pre-commit dected issues and turn test on for all files

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,18 +10,12 @@ jobs:
 
     steps:
       - name: Install Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10'
 
       - name: Checkout code
-        uses: actions/checkout@v3
-
-      - name: Setup environment
-        run: |
-          pip install pre-commit
-          pre-commit install
+        uses: actions/checkout@v4
 
       - name: Run precommit check
-        run: |
-          pre-commit run --file tests/* --files demos/*
+        uses: pre-commit/action@v3.0.1

--- a/tools/qm-storage-settings
+++ b/tools/qm-storage-settings
@@ -48,8 +48,8 @@ setup_init() {
         "${ROOTFS}/usr/share/containers/storage.conf"
     )
 
-    for STORAGE_CONF_PATH in ${STORAGE_CONF_PATHS[@]}; do
-        if [ -f ${STORAGE_CONF_PATH} ]; then
+    for STORAGE_CONF_PATH in "${STORAGE_CONF_PATHS[@]}"; do
+        if [ -f "${STORAGE_CONF_PATH}" ]; then
             STORAGE_CONFIG="${STORAGE_CONF_PATH}"
             return
         fi


### PR DESCRIPTION
Fix missing double quoting in tools/qm-storage-settings

Fixes missing double quotes introduced in #479.
Not detected by pre-commit action as it's not configured  to run on all files.
```
In tools/qm-storage-settings fix for:
     for STORAGE_CONF_PATH in ${STORAGE_CONF_PATHS[@]}; do
                                 ^----------------------^ SC2068 (error): Double quote array expansions to avoid re-splitting elements.

In tools/qm-storage-settings line 52:
        if [ -f ${STORAGE_CONF_PATH} ]; then
                ^------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.
```

Then, enabling pre-commit on all files preventing this to happen again.