### PR TITLE
Add SELinux rules for Wayland

### DIFF
--- a/qm.if
+++ b/qm.if
@@ -39,12 +39,14 @@ template(`qm_domain_template',`
 		type sysctl_irq_t;
 		type sysctl_t;
 		type system_dbusd_t;
+		type systemd_hostnamed_t;
 		type systemd_logind_t;
 		type systemd_machined_t;
 		type unconfined_service_t;
 		type bpf_t;
 		type container_devpts_t;
 		type net_conf_t;
+		type getty_t;
 	')
 
 	type $1_t;
@@ -397,10 +399,14 @@ template(`qm_domain_template',`
 
 	qm_container_template($1, wayland)
 
-	allow $1_container_wayland_t $1_file_t:dir { add_name write };
+	allow $1_container_wayland_t $1_file_t:dir { add_name write watch };
 	allow $1_container_wayland_t $1_file_t:file { create write };
 	allow $1_container_wayland_t $1_file_t:sock_file { create write };
+	allow $1_container_wayland_t $1_t:unix_stream_socket connectto;
 	dev_read_sysfs($1_container_wayland_t)
+
+	allow getty_t $1_file_type:chr_file { read write };
+	systemd_dbus_chat_hostnamed(systemd_hostnamed_t)
 
 	read_files_pattern($1_container_domain, $1_container_ro_file_t,$1_container_ro_file_t)
 	read_lnk_files_pattern($1_container_domain, $1_container_ro_file_t,$1_container_ro_file_t)

--- a/qm.if
+++ b/qm.if
@@ -79,6 +79,7 @@ template(`qm_domain_template',`
 	manage_files_pattern($1_t, $1_file_type, $1_file_type)
 	can_exec($1_t, $1_file_type)
 	allow $1_t $1_file_type:chr_file mounton;
+	allow $1_t $1_file_type:sock_file mounton;
 
 	list_dirs_pattern($1_t, ipc_var_run_t, ipc_var_run_t)
 	allow $1_t ipc_var_run_t:dir mounton;
@@ -100,6 +101,7 @@ template(`qm_domain_template',`
 	container_exec_share_files($1_container_domain)
 	allow $1_container_domain container_ro_file_t:file execmod;
 
+	allow init_t $1_file_type:file { open read };
 	manage_blk_files_pattern(init_t, $1_file_type, $1_file_type)
 	manage_chr_files_pattern(init_t, $1_file_type, $1_file_type)
 	manage_dirs_pattern(init_t, $1_file_type, $1_file_type)
@@ -142,7 +144,7 @@ template(`qm_domain_template',`
 	allow $1_t self:user_namespace all_user_namespace_perms;
 	allow $1_t self:bpf { map_create map_read map_write prog_load prog_run };
 	allow $1_t self:cap_userns { audit_write chown dac_override dac_read_search fowner fsetid kill net_bind_service net_admin net_raw setfcap setgid setpcap setuid sys_admin sys_boot sys_chroot sys_ptrace sys_resource };
-	allow $1_t self:capability { audit_write chown dac_override dac_read_search fowner fsetid kill net_bind_service net_admin net_raw setfcap setgid setpcap setuid sys_admin sys_boot sys_chroot sys_nice sys_ptrace sys_resource };
+	allow $1_t self:capability { audit_write chown dac_override dac_read_search fowner fsetid kill net_bind_service net_admin net_raw setfcap setgid setpcap setuid sys_admin sys_boot sys_chroot sys_nice sys_ptrace sys_resource sys_tty_config };
 	allow $1_t self:capability2 { audit_read bpf perfmon};
 
 	allow $1_t self:packet_socket create_socket_perms;
@@ -394,6 +396,11 @@ template(`qm_domain_template',`
 	logging_send_syslog_msg($1_container_init_t)
 
 	qm_container_template($1, wayland)
+
+	allow $1_container_wayland_t $1_file_t:dir { add_name write };
+	allow $1_container_wayland_t $1_file_t:file { create write };
+	allow $1_container_wayland_t $1_file_t:sock_file { create write };
+	dev_read_sysfs($1_container_wayland_t)
 
 	read_files_pattern($1_container_domain, $1_container_ro_file_t,$1_container_ro_file_t)
 	read_lnk_files_pattern($1_container_domain, $1_container_ro_file_t,$1_container_ro_file_t)


### PR DESCRIPTION
Minimal set of SELinux rules to allow running Wayland compositor in the QM container.