### PR TITLE
qm.if: add remaining wayland rules

### DIFF
--- a/qm.if
+++ b/qm.if
@@ -399,13 +399,19 @@ template(`qm_domain_template',`
 
 	qm_container_template($1, wayland)
 
-	allow $1_container_wayland_t $1_file_t:dir { add_name write watch };
+	allow $1_container_wayland_t $1_file_t:chr_file map;
+	allow $1_container_wayland_t $1_file_t:dir { add_name create write watch };
 	allow $1_container_wayland_t $1_file_t:file { create write };
 	allow $1_container_wayland_t $1_file_t:sock_file { create write };
 	allow $1_container_wayland_t $1_t:unix_stream_socket connectto;
+	allow $1_container_wayland_t $1_t:dbus send_msg;
+	allow $1_t $1_container_wayland_t:dbus send_msg;
 	dev_read_sysfs($1_container_wayland_t)
 
 	allow getty_t $1_file_type:chr_file { read write };
+
+	allow systemd_hostnamed_t $1_file_t:dir search;
+	allow systemd_hostnamed_t $1_file_t:file { getattr open read };
 	systemd_dbus_chat_hostnamed(systemd_hostnamed_t)
 
 	read_files_pattern($1_container_domain, $1_container_ro_file_t,$1_container_ro_file_t)


### PR DESCRIPTION
Add remaining rules required to support
booting and running the wayland scenario,
with a compositor, session creation,
qm dbus management, and all required pieces.

Note that running pem_selinux for creating
the session will be blocked, as it falls back
to unconfined_u with the current rules.