### PR TITLE
verify /dev/mem is not present in QM partition

### DIFF
--- a/tests/ffi/dev_mem_not_present/PURPOSE
+++ b/tests/ffi/dev_mem_not_present/PURPOSE
@@ -1,0 +1,10 @@
+Verifies that /dev/mem is not present in QM partition.
+
+This test execute `test -e /dev/mem` in QM partition, no other input.
+    podman exec qm test -e /dev/mem
+
+Expected result:
+    out: [ INFO  ] PASS: check_dev_mem_not_present: As expected, /dev/mem is not present in QM partition.
+
+Results location:
+    /plans/e2e/ffi/report/default-0/junit.xml

--- a/tests/ffi/dev_mem_not_present/README.md
+++ b/tests/ffi/dev_mem_not_present/README.md
@@ -1,0 +1,7 @@
+# FFI - dev_mem_not_present
+
+This test is intended to confirm that /dev/mem is not present in QM partition.
+
+## This Test Set includes these tests
+
+1. Confirm that /dev/mem is not present in QM partition.

--- a/tests/ffi/dev_mem_not_present/main.fmf
+++ b/tests/ffi/dev_mem_not_present/main.fmf
@@ -1,0 +1,5 @@
+summary: Test /dev/mem is not present in QM partition.
+test: /bin/bash ./test.sh
+duration: 10m
+tag: ffi
+framework: shell

--- a/tests/ffi/dev_mem_not_present/main.fmf
+++ b/tests/ffi/dev_mem_not_present/main.fmf
@@ -3,3 +3,4 @@ test: /bin/bash ./test.sh
 duration: 10m
 tag: ffi
 framework: shell
+id: daa57e78-58da-4792-8eef-59a6b32745a2

--- a/tests/ffi/dev_mem_not_present/test.sh
+++ b/tests/ffi/dev_mem_not_present/test.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -euvx
+
+# shellcheck disable=SC1091
+. ../../e2e/lib/utils
+
+check_dev_mem_not_present(){
+    # Check /dev/mem is not present in QM partition
+    if podman exec qm test -e /dev/mem; then
+        info_message "Found /dev/mem in QM partition: $(podman exec -t qm ls -l /dev/mem)"
+        info_message "FAIL: check_dev_mem_not_present: Check for /dev/mem in QM partition failed, it should not be present."
+        exit 1
+    else
+        info_message "PASS: check_dev_mem_not_present: As expected, /dev/mem is not present in QM partition."
+        exit 0
+    fi
+}
+
+check_dev_mem_not_present


### PR DESCRIPTION
I want ensure that /dev/mem is not accesible inside QM partition.

Test Design (improved based on PR review):

1. Using test expression in QM partition:

    Execute the following command:

    `podman exec qm test -e /dev/mem`
    
2. Expected Result:

    /dev/mem does not exist, the command returns a non-zero value

3. Verify whether the test passed or not:

    PASS: if the command returns a non-zero value, it means /dev/mem is not present
    FAIL:  if the command returns 0, it means /dev/mem is present


