### PR TITLE
Attempts to access forbidden file system resource

### DIFF
--- a/tests/ffi/attempts_to_access_forbidden_file_system_resource/devices/PURPOSE
+++ b/tests/ffi/attempts_to_access_forbidden_file_system_resource/devices/PURPOSE
@@ -1,0 +1,20 @@
+Title:
+    Validate that some devices are not available inside the QM partition.
+
+Description:
+    The QM partition configuration defines a set of available filesystem resources (devices, networks, shared memory, etc).
+    These and only these resources are expected to be present in the QM partition's file system.
+
+Input:
+    This test set executes the following commands respectively:
+        `podman exec qm test -c /dev/console`
+        `podman exec qm test -d /dev/disk`
+        `podman exec qm test -c /dev/kmsg`
+
+Expected Result:
+    out: [ INFO  ] PASS: check_dev_console_not_available: As expected, /dev/console is not available in the QM partition.
+    out: [ INFO  ] PASS: check_dev_disk_not_available: As expected, /dev/disk is not available in the QM partition.
+    out: [ INFO  ] PASS: check_dev_kmsg_not_available: As expected, /dev/kmsg is not available in the QM partition.
+
+Jira:
+    https://issues.redhat.com/browse/VROOM-21932

--- a/tests/ffi/attempts_to_access_forbidden_file_system_resource/devices/README.md
+++ b/tests/ffi/attempts_to_access_forbidden_file_system_resource/devices/README.md
@@ -1,0 +1,9 @@
+# FFI - attempts_to_access_forbidden_file_system_resource/devices
+
+This test is intended to confirm that resources (devices, networks, shared memory, etc) present in the file system match the expectations based on the QM partition configuration.
+
+## This Test Set includes these tests
+
+1. Confirm that the device /dev/console is not available in the QM partition.
+2. Confirm that the device /dev/disk is not available in the QM partition.
+3. Confirm that the device /dev/kmsg is not available in the QM partition.

--- a/tests/ffi/attempts_to_access_forbidden_file_system_resource/devices/check_dev_console.fmf
+++ b/tests/ffi/attempts_to_access_forbidden_file_system_resource/devices/check_dev_console.fmf
@@ -1,0 +1,5 @@
+summary: Test that the device /dev/console is not available in the QM partition.
+test: /bin/bash ./check_dev_console.sh
+duration: 10m
+tag: ffi
+framework: shell

--- a/tests/ffi/attempts_to_access_forbidden_file_system_resource/devices/check_dev_console.sh
+++ b/tests/ffi/attempts_to_access_forbidden_file_system_resource/devices/check_dev_console.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -euvx
+
+# shellcheck disable=SC1091
+. ../../../e2e/lib/utils
+
+check_dev_console_not_available(){
+    # Check /dev/console is not available in the QM partition
+    if podman exec qm test -c /dev/console; then
+        info_message "Found /dev/console in the QM partition: $(podman exec -t qm ls -l /dev/console)"
+        info_message "FAIL: check_dev_console_not_available: Check for /dev/console in the QM partition failed, it should not be available."
+        exit 1
+    else
+        info_message "PASS: check_dev_console_not_available: As expected, /dev/console is not available in the QM partition."
+        exit 0
+    fi
+}
+
+check_dev_console_not_available

--- a/tests/ffi/attempts_to_access_forbidden_file_system_resource/devices/check_dev_disk.fmf
+++ b/tests/ffi/attempts_to_access_forbidden_file_system_resource/devices/check_dev_disk.fmf
@@ -1,0 +1,5 @@
+summary: Test that the device /dev/disk is not available in the QM partition.
+test: /bin/bash ./check_dev_disk.sh
+duration: 10m
+tag: ffi
+framework: shell

--- a/tests/ffi/attempts_to_access_forbidden_file_system_resource/devices/check_dev_disk.sh
+++ b/tests/ffi/attempts_to_access_forbidden_file_system_resource/devices/check_dev_disk.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -euvx
+
+# shellcheck disable=SC1091
+. ../../../e2e/lib/utils
+
+check_dev_disk_not_available(){
+    # Check /dev/disk is not available in the QM partition
+    if podman exec qm test -d /dev/disk; then
+        info_message "Found /dev/disk in the QM partition: $(podman exec -t qm ls -l /dev/disk)"
+        info_message "FAIL: check_dev_disk_not_available: Check for /dev/disk in the QM partition failed, it should not be available."
+        exit 1
+    else
+        info_message "PASS: check_dev_disk_not_available: As expected, /dev/disk is not available in the QM partition."
+        exit 0
+    fi
+}
+
+check_dev_disk_not_available

--- a/tests/ffi/attempts_to_access_forbidden_file_system_resource/devices/check_dev_kmsg.fmf
+++ b/tests/ffi/attempts_to_access_forbidden_file_system_resource/devices/check_dev_kmsg.fmf
@@ -1,0 +1,5 @@
+summary: Test that the device /dev/kmsg is not available in the QM partition.
+test: /bin/bash ./check_dev_kmsg.sh
+duration: 10m
+tag: ffi
+framework: shell

--- a/tests/ffi/attempts_to_access_forbidden_file_system_resource/devices/check_dev_kmsg.sh
+++ b/tests/ffi/attempts_to_access_forbidden_file_system_resource/devices/check_dev_kmsg.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -euvx
+
+# shellcheck disable=SC1091
+. ../../../e2e/lib/utils
+
+check_dev_kmsg_not_available(){
+    # Check /dev/kmsg is not available in the QM partition
+    if podman exec qm test -c /dev/kmsg; then
+        info_message "Found /dev/kmsg in the QM partition: $(podman exec -t qm ls -l /dev/kmsg)"
+        info_message "FAIL: check_dev_kmsg_not_available: Check for /dev/kmsg in the QM partition failed, it should not be available."
+        exit 1
+    else
+        info_message "PASS: check_dev_kmsg_not_available: As expected, /dev/kmsg is not available in the QM partition."
+        exit 0
+    fi
+}
+
+check_dev_kmsg_not_available

--- a/tests/ffi/attempts_to_access_forbidden_file_system_resource/regular_os_files/PURPOSE
+++ b/tests/ffi/attempts_to_access_forbidden_file_system_resource/regular_os_files/PURPOSE
@@ -1,0 +1,19 @@
+Title:
+    Validate that the QM directories on the host are not accessible inside the QM partition.
+
+Description:
+    The qm package is not installed in the QM partition (its only on the host). So check that you cannot access its directories.
+
+Input:
+    This test set executes the following commands respectively:
+        `podman exec qm test -d /etc/qm`
+        `podman exec qm test -d /usr/lib/qm`
+        `podman exec qm test -d /usr/share/qm`
+
+Expected Result:
+    out: [ INFO  ] PASS: check_etc_qm_not_accessible: As expected, /etc/qm is not accessible in the QM partition.
+    out: [ INFO  ] PASS: check_usr_lib_qm_not_accessible: As expected, /usr/lib/qm is not accessible in the QM partition.
+    out: [ INFO  ] PASS: check_usr_share_qm_not_accessible: As expected, /usr/share/qm is not accessible in the QM partition.
+
+Jira:
+    https://issues.redhat.com/browse/VROOM-21932

--- a/tests/ffi/attempts_to_access_forbidden_file_system_resource/regular_os_files/README.md
+++ b/tests/ffi/attempts_to_access_forbidden_file_system_resource/regular_os_files/README.md
@@ -1,0 +1,9 @@
+# FFI - attempts_to_access_forbidden_file_system_resource/regular_os_files
+
+This test is intended to confirm that resources (devices, networks, shared memory, etc) present in the file system match the expectations based on the QM partition configuration.
+
+## This Test Set includes these tests
+
+1. Confirm that the directory /etc/qm cannot be accessed in the QM partition.
+2. Confirm that the directory /usr/lib/qm cannot be accessed in the QM partition.
+3. Confirm that the directory /usr/share/qm cannot be accessed in the QM partition.

--- a/tests/ffi/attempts_to_access_forbidden_file_system_resource/regular_os_files/check_etc_qm.fmf
+++ b/tests/ffi/attempts_to_access_forbidden_file_system_resource/regular_os_files/check_etc_qm.fmf
@@ -1,0 +1,5 @@
+summary: Test that the directory /etc/qm cannot be accessed in the QM partition.
+test: /bin/bash ./check_etc_qm.sh
+duration: 10m
+tag: ffi
+framework: shell

--- a/tests/ffi/attempts_to_access_forbidden_file_system_resource/regular_os_files/check_etc_qm.sh
+++ b/tests/ffi/attempts_to_access_forbidden_file_system_resource/regular_os_files/check_etc_qm.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -euvx
+
+# shellcheck disable=SC1091
+. ../../../e2e/lib/utils
+
+check_etc_qm_not_accessible(){
+    # Check /etc/qm is not accessible in the QM partition
+    if podman exec qm test -d /etc/qm; then
+        info_message "Found /etc/qm in the QM partition: $(podman exec -t qm ls -l /etc/qm)"
+        info_message "FAIL: check_etc_qm_not_accessible: Check for /etc/qm in the QM partition failed, it should not be accessible."
+        exit 1
+    else
+        info_message "PASS: check_etc_qm_not_accessible: As expected, /etc/qm is not accessible in the QM partition."
+        exit 0
+    fi
+}
+
+check_etc_qm_not_accessible

--- a/tests/ffi/attempts_to_access_forbidden_file_system_resource/regular_os_files/check_usr_lib_qm.fmf
+++ b/tests/ffi/attempts_to_access_forbidden_file_system_resource/regular_os_files/check_usr_lib_qm.fmf
@@ -1,0 +1,5 @@
+summary: Test that the directory /usr/lib/qm cannot be accessed in the QM partition.
+test: /bin/bash ./check_usr_lib_qm.sh
+duration: 10m
+tag: ffi
+framework: shell

--- a/tests/ffi/attempts_to_access_forbidden_file_system_resource/regular_os_files/check_usr_lib_qm.sh
+++ b/tests/ffi/attempts_to_access_forbidden_file_system_resource/regular_os_files/check_usr_lib_qm.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -euvx
+
+# shellcheck disable=SC1091
+. ../../../e2e/lib/utils
+
+check_usr_lib_qm_not_accessible(){
+    # Check /usr/lib/qm is not accessible in the QM partition
+    if podman exec qm test -d /usr/lib/qm; then
+        info_message "Found /usr/lib/qm in the QM partition: $(podman exec -t qm ls -l /usr/lib/qm)"
+        info_message "FAIL: check_usr_lib_qm_not_accessible: Check for /usr/lib/qm in the QM partition failed, it should not be accessible."
+        exit 1
+    else
+        info_message "PASS: check_usr_lib_qm_not_accessible: As expected, /usr/lib/qm is not accessible in the QM partition."
+        exit 0
+    fi
+}
+
+check_usr_lib_qm_not_accessible

--- a/tests/ffi/attempts_to_access_forbidden_file_system_resource/regular_os_files/check_usr_share_qm.fmf
+++ b/tests/ffi/attempts_to_access_forbidden_file_system_resource/regular_os_files/check_usr_share_qm.fmf
@@ -1,0 +1,5 @@
+summary: Test that the directory /usr/share/qm cannot be accessed in the QM partition.
+test: /bin/bash ./check_usr_share_qm.sh
+duration: 10m
+tag: ffi
+framework: shell

--- a/tests/ffi/attempts_to_access_forbidden_file_system_resource/regular_os_files/check_usr_share_qm.sh
+++ b/tests/ffi/attempts_to_access_forbidden_file_system_resource/regular_os_files/check_usr_share_qm.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -euvx
+
+# shellcheck disable=SC1091
+. ../../../e2e/lib/utils
+
+check_usr_share_qm_not_accessible(){
+    # Check /usr/share/qm is not accessible in the QM partition
+    if podman exec qm test -d /usr/share/qm; then
+        info_message "Found /usr/share/qm in the QM partition: $(podman exec -t qm ls -l /usr/share/qm)"
+        info_message "FAIL: check_usr_share_qm_not_accessible: Check for /usr/share/qm in the QM partition failed, it should not be accessible."
+        exit 1
+    else
+        info_message "PASS: check_usr_share_qm_not_accessible: As expected, /usr/share/qm is not accessible in the QM partition."
+        exit 0
+    fi
+}
+
+check_usr_share_qm_not_accessible

--- a/tests/ffi/attempts_to_access_forbidden_file_system_resource/shared_memory_files/PURPOSE
+++ b/tests/ffi/attempts_to_access_forbidden_file_system_resource/shared_memory_files/PURPOSE
@@ -1,0 +1,15 @@
+Title:
+    Validate that SharedMemory files present in the file system match the expectations based on the QM partition configuration.
+
+Description:
+    Create a file /dev/shm/on-host outside the QM partition, ensure it is not visible in /dev/shm inside the QM partition.
+
+Input:
+    `touch /dev/shm/on-host`
+
+Expected Result:
+    out: [ INFO  ] Successfully created the file /dev/shm/on-host outside the QM partition.
+    out: [ INFO  ] PASS: check_dev_shm_file_not_visible_in_qm: As expected, /dev/shm/on-host is not visible in the QM partition.
+
+Jira:
+    https://issues.redhat.com/browse/VROOM-21932

--- a/tests/ffi/attempts_to_access_forbidden_file_system_resource/shared_memory_files/README.md
+++ b/tests/ffi/attempts_to_access_forbidden_file_system_resource/shared_memory_files/README.md
@@ -1,0 +1,7 @@
+# FFI - attempts_to_access_forbidden_file_system_resource/shared_memory_files
+
+This test is intended to confirm that resources (devices, networks, shared memory, etc) present in the file system match the expectations based on the QM partition configuration.
+
+## This Test Set includes these tests
+
+1. Confirm that the file created in /dev/shm/ outside the QM partition that are not visible in /dev/shm inside the QM partition.

--- a/tests/ffi/attempts_to_access_forbidden_file_system_resource/shared_memory_files/check_dev_shm.fmf
+++ b/tests/ffi/attempts_to_access_forbidden_file_system_resource/shared_memory_files/check_dev_shm.fmf
@@ -1,0 +1,5 @@
+summary: Test that the file created in /dev/shm/ outside the QM partition that are not visible in /dev/shm inside the QM partition.
+test: /bin/bash ./check_dev_shm.sh
+duration: 10m
+tag: ffi
+framework: shell

--- a/tests/ffi/attempts_to_access_forbidden_file_system_resource/shared_memory_files/check_dev_shm.sh
+++ b/tests/ffi/attempts_to_access_forbidden_file_system_resource/shared_memory_files/check_dev_shm.sh
@@ -1,0 +1,27 @@
+#!/bin/bash -euvx
+
+# shellcheck disable=SC1091
+. ../../../e2e/lib/utils
+
+check_dev_shm_file_not_visible_in_qm(){
+    # Create a file /dev/shm/on-host outside the QM partition
+    touch /dev/shm/on-host
+    if test -e /dev/shm/on-host; then
+        info_message "Successfully created the file /dev/shm/on-host outside the QM partition."
+    else
+        info_message "FAIL: check_dev_shm_file_not_visible_in_qm: Failed to create /dev/shm/on-host outside the QM partition."
+        exit 1
+    fi
+
+    # Check for file /dev/shm/on-host is not visible inside the QM partition.
+    if podman exec qm test -e /dev/shm/on-host; then
+        info_message "Found /dev/shm/on-host in the QM partition: $(podman exec -t qm ls -l /dev/shm/on-host)"
+        info_message "FAIL: check_dev_shm_file_not_visible_in_qm: Check for /dev/shm/on-host failed, it should not be visible in the QM partition."
+        exit 1
+    else
+        info_message "PASS: check_dev_shm_file_not_visible_in_qm: As expected, /dev/shm/on-host is not visible in the QM partition."
+        exit 0
+    fi
+}
+
+check_dev_shm_file_not_visible_in_qm

--- a/tests/ffi/attempts_to_access_forbidden_file_system_resource/sockets/PURPOSE
+++ b/tests/ffi/attempts_to_access_forbidden_file_system_resource/sockets/PURPOSE
@@ -1,0 +1,18 @@
+Title:
+    Validate that the network resources present in the file system match the expectations based on the QM partition configuration.
+
+Description:
+    Check that /run/systemd/journal/socket have different inode number inside and outside of the QM partition. Various sockets should not be available in the QM container, check that /run/udev/control doesn't exists.
+
+Input:
+    This test set executes the following commands:
+        `stat --printf='%i' /run/systemd/journal/socket`
+        `podman exec qm stat --printf='%i' /run/systemd/journal/socket`
+        `podman exec qm test -e /run/udev/control`
+
+Expected Result:
+    out: [ INFO  ] PASS: check_run_systemd_journal_socket_inode_number: As expected, /run/systemd/journal/socket have different inode number inside and outside of the QM partition.
+    out: [ INFO  ] PASS: check_run_udev_control_not_exist: As expected, /run/udev/control dose not exist in the QM partition.
+
+Jira:
+    https://issues.redhat.com/browse/VROOM-21932

--- a/tests/ffi/attempts_to_access_forbidden_file_system_resource/sockets/README.md
+++ b/tests/ffi/attempts_to_access_forbidden_file_system_resource/sockets/README.md
@@ -1,0 +1,8 @@
+# FFI - attempts_to_access_forbidden_file_system_resource/sockets
+
+This test is intended to confirm that resources (devices, networks, shared memory, etc) present in the file system match the expectations based on the QM partition configuration.
+
+## This Test Set includes these tests
+
+1. Confirm that /run/systemd/journal/socket have different inode number inside and outside of the QM partition.
+2. Confirm that the socket /run/udev/control does not exist in the QM partition.

--- a/tests/ffi/attempts_to_access_forbidden_file_system_resource/sockets/check_run_systemd_journal_socket.fmf
+++ b/tests/ffi/attempts_to_access_forbidden_file_system_resource/sockets/check_run_systemd_journal_socket.fmf
@@ -1,0 +1,5 @@
+summary: Test that /run/systemd/journal/socket have different inode number inside and outside of the QM partition.
+test: /bin/bash ./check_run_systemd_journal_socket.sh
+duration: 10m
+tag: ffi
+framework: shell

--- a/tests/ffi/attempts_to_access_forbidden_file_system_resource/sockets/check_run_systemd_journal_socket.sh
+++ b/tests/ffi/attempts_to_access_forbidden_file_system_resource/sockets/check_run_systemd_journal_socket.sh
@@ -1,0 +1,25 @@
+#!/bin/bash -euvx
+
+# shellcheck disable=SC1091
+. ../../../e2e/lib/utils
+
+check_run_systemd_journal_socket_inode_number(){
+    # Get inode number of /run/systemd/journal/socket inside and outside of the QM partition.
+    inode_number_in_host=$(stat --printf='%i' /run/systemd/journal/socket)
+    inode_number_in_qm=$(podman exec qm stat --printf='%i' /run/systemd/journal/socket)
+
+    # Check if the inode numbers inside and outside of the QM partition are different.
+    if [ "$inode_number_in_host" -eq "$inode_number_in_qm" ]; then
+        info_message "In the host, inode number of /run/systemd/journal/socket is: ${inode_number_in_host}"
+        info_message "In the QM partition, inode number of /run/systemd/journal/socket is: ${inode_number_in_qm}"
+        info_message "FAIL: check_run_systemd_journal_socket_inode_number: Checking inode number of /run/systemd/journal/socket failed, \
+it should have different inode number inside and outside of the QM partition."
+        exit 1
+    else
+        info_message "PASS: check_run_systemd_journal_socket_inode_number: As expected, /run/systemd/journal/socket have different \
+inode number inside and outside of the QM partition."
+        exit 0
+    fi
+}
+
+check_run_systemd_journal_socket_inode_number

--- a/tests/ffi/attempts_to_access_forbidden_file_system_resource/sockets/check_run_udev_control.fmf
+++ b/tests/ffi/attempts_to_access_forbidden_file_system_resource/sockets/check_run_udev_control.fmf
@@ -1,0 +1,5 @@
+summary: Test that the socket /run/udev/control does not exist in the QM partition.
+test: /bin/bash ./check_run_udev_control.sh
+duration: 10m
+tag: ffi
+framework: shell

--- a/tests/ffi/attempts_to_access_forbidden_file_system_resource/sockets/check_run_udev_control.sh
+++ b/tests/ffi/attempts_to_access_forbidden_file_system_resource/sockets/check_run_udev_control.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -euvx
+
+# shellcheck disable=SC1091
+. ../../../e2e/lib/utils
+
+check_run_udev_control_not_exist(){
+    # Check /run/udev/control is not exist in the QM partition
+    if podman exec qm test -e /run/udev/control; then
+        info_message "Found /run/udev/control in the QM partition: $(podman exec -t qm ls -l /run/udev/control)"
+        info_message "FAIL: check_run_udev_control_not_exist: Check for /run/udev/control in the QM partition failed, it should not exist."
+        exit 1
+    else
+        info_message "PASS: check_run_udev_control_not_exist: As expected, /run/udev/control dose not exist in the QM partition."
+        exit 0
+    fi
+}
+
+check_run_udev_control_not_exist


### PR DESCRIPTION
As the namespace is limited for the QM container, there is no method for an application to actively attempt to access a resource that is not present in the file system. Therefore it must be shown that the resources present in the file system match the expectations based on the configuration.
The QM partition configuration defines a set of available filesystem resources (devices, networks, shared memory, etc). These and only these resources are expected to be present in the QM partition's file system.