### PR TITLE
improve prepare_images and increase duration

### DIFF
--- a/tests/ffi/agent-flood/main.fmf
+++ b/tests/ffi/agent-flood/main.fmf
@@ -1,6 +1,6 @@
 summary: Test bluechi against stress agent
 test: /bin/bash ./test.sh
-duration: 10m
+duration: 20m
 tag: ffi
 order: 70
 framework: shell

--- a/tests/ffi/common/prepare.sh
+++ b/tests/ffi/common/prepare.sh
@@ -40,12 +40,15 @@ prepare_images() {
    exec_cmd "podman pull quay.io/centos-sig-automotive/ffi-tools:latest"
    # Copy container image registry to /var/qm/lib/containers
    image_id=$(podman images | grep quay.io/centos-sig-automotive/ffi-tools | awk -F " " '{print $3}')
-   if [ ! -d "${QM_HOST_REGISTRY_DIR}" ]; then
-       exec_cmd "mkdir -p ${QM_HOST_REGISTRY_DIR}"
-       exec_cmd "podman push ${image_id} dir:${QM_HOST_REGISTRY_DIR}/tools-ffi:latest"
-       # Remove image to save /var space
-       exec_cmd "podman rmi -f ${image_id}"
+
+   if [ -d "${QM_HOST_REGISTRY_DIR}" ]; then
+      rm -rf ${QM_HOST_REGISTRY_DIR}
    fi
+
+   exec_cmd "mkdir -p ${QM_HOST_REGISTRY_DIR}"
+   exec_cmd "podman push ${image_id} dir:${QM_HOST_REGISTRY_DIR}/tools-ffi:latest"
+   # Remove image to save /var space
+   exec_cmd "podman rmi -f ${image_id}"
 }
 
 run_container_in_qm() {

--- a/tests/ffi/deny_sched_setattr/main.fmf
+++ b/tests/ffi/deny_sched_setattr/main.fmf
@@ -1,6 +1,6 @@
 summary: Test QM not allow SCHED_DEADLINE be set via sched_setattr() syscall
 test: /bin/bash ./test.sh
-duration: 10m
+duration: 20m
 tag: ffi
 framework: shell
 id: 6e0d8dd9-2106-4f57-be1b-98f443145b36

--- a/tests/ffi/deny_set_scheduler/main.fmf
+++ b/tests/ffi/deny_set_scheduler/main.fmf
@@ -1,6 +1,6 @@
 summary: Test the sched_setscheduler() syscall inside QM is not allowed
 test: /bin/bash ./test.sh
-duration: 10m
+duration: 20m
 tag: ffi
 framework: shell
 id: 9100f240-b4e8-4d73-87fe-c607ed1d89b2

--- a/tests/ffi/memory/main.fmf
+++ b/tests/ffi/memory/main.fmf
@@ -1,6 +1,6 @@
 summary: Test is calling systemd as stand alone test
 test: /bin/bash ./test.sh
-duration: 15m
+duration: 20m
 tag: ffi
 framework: shell
 id: fff26f33-a051-4d9e-aae2-97935e425273

--- a/tests/ffi/qm-oom-score-adj/main.fmf
+++ b/tests/ffi/qm-oom-score-adj/main.fmf
@@ -1,6 +1,6 @@
 summary: Test the qm's oom-score-adj values
 test: /bin/bash ./test.sh
-duration: 10m
+duration: 20m
 tag: ffi
 framework: shell
 id: 6e6c5cea-efc7-48e9-8b4c-d355229ab1c2


### PR DESCRIPTION
1. When each test case is executed, if directory `/var/qm/lib/containers/registry` exists, delete it first, then create the directory and copy the `ffi-tools` container image to it.
2. Pulling `ffi-tools` image often times out, so extend the duration.

Resolve https://github.com/containers/qm/issues/506