### PR TITLE
Patch for common.sh

### DIFF
--- a/tests/ffi/common/prepare.sh
+++ b/tests/ffi/common/prepare.sh
@@ -67,3 +67,9 @@ run_container_in_qm() {
       tail -f /dev/null\""
    exec_cmd "${run_ctr_in_qm}"
 }
+
+init_ffi() {
+        disk_cleanup
+        prepare_test
+        reload_config
+}


### PR DESCRIPTION
@dougsland suggested to add this patch to prepare.sh, so people will be able to init the ffi, by calling single init_ffi function, which includes all three functions (disk_cleanup,  prepare_test, at once in their code, reload_config), instead of calling 3 of them one by one in their code.