### PR TITLE
Fix agent-flood

### DIFF
--- a/tests/ffi/agent-flood/test.sh
+++ b/tests/ffi/agent-flood/test.sh
@@ -79,32 +79,20 @@ get_qm_network_mode(){
     echo "${qm_network_mode}"
 }
 
-disk_cleanup
-prepare_test
-reload_config
+init_ffi
 prepare_images
 
 # Assign value to ${controller_host_ip} according to qm network mode
 if [ "$(get_qm_network_mode)" == "private" ]; then
     controller_host_ip=$(hostname -I | awk '{print $1}')
 else
-    echo "qm network mode should be private not: $(get_qm_network_mode)"
+    info_message "qm network mode should be private, not: $(get_qm_network_mode)"
     exit 1
 fi
 
 #Stop QM bluechi-agent
 exec_cmd "podman exec -it qm /bin/bash -c \
          \"systemctl stop bluechi-agent\""
-
-# This is the workaround when ControllerHost is not in /etc/qm/bluechi/agent.conf.d/agent.conf
-# Add ControllerHost to this configuration file
-qm_bluechi_agent_config_file="/etc/qm/bluechi/agent.conf.d/agent.conf"
-if test -f "${qm_bluechi_agent_config_file}"; then
-    sed -i '$a \ControllerHost='"${controller_host_ip}"'' ${qm_bluechi_agent_config_file}
-else
-    echo "Configuration file not found: ${qm_bluechi_agent_config_file}"
-    exit 1
-fi
 
 #Prepare quadlet files for testing containers
 setup_test_containers_in_qm


### PR DESCRIPTION
fix https://github.com/containers/qm/issues/517

Removed the code block for inserting `controller host ip` to /etc/qm/bluechi/agent.conf.d/agent.conf, because if `set-ffi-env-e2e` is not called, then this file may not exist. And the status of bluechi-agent `qm.localrootfs` does not affect the status of `bluechi-tester-1` and `bluechi-tester-2` in this test case.
