### PR TITLE
test: replace partprobe with parted

### DIFF
--- a/rpm/qm.spec
+++ b/rpm/qm.spec
@@ -58,6 +58,7 @@ BuildRequires: pkgconfig(systemd)
 BuildRequires: selinux-policy >= %_selinux_policy_version
 BuildRequires: selinux-policy-devel >= %_selinux_policy_version
 
+Requires: parted
 Requires: containers-common
 Requires: selinux-policy >= %_selinux_policy_version
 Requires(post): selinux-policy-base >= %_selinux_policy_version

--- a/tests/e2e/lib/diskutils
+++ b/tests/e2e/lib/diskutils
@@ -56,7 +56,7 @@ select_disk_to_partition(){
         fi
       fi
   done
-  partprobe
+  parted /dev/${DISK} rescan
 }
 
 create_qm_var_part() {


### PR DESCRIPTION
partprobe requires parted, blockdev uses util-linux-core which most distros ship it in different archs.