### PR TITLE
Remove #!/bin/bash -euvx options

### DIFF
--- a/tests/ffi/qm-oom-score-adj/test.sh
+++ b/tests/ffi/qm-oom-score-adj/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -euvx
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/ffi/qm-oom-score-adj/test.sh
+++ b/tests/ffi/qm-oom-score-adj/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -euvx
+#!/bin/bash
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Refining code for https://github.com/nsednev/qm/blob/64fc09a13b376604782d98d8447ff86ed630e119/tests/ffi/qm-oom-score-adj/test.sh#L1C1-L1C18

The shebang (#!) at the beginning of the line indicates that the script should be executed using the specified interpreter, which in this case is /bin/bash. This means that the script will be run using the Bash shell.

Following the shebang, there are several options provided to the Bash interpreter:

-e: This option instructs the script to exit immediately if any command within the script returns a non-zero exit status. This is useful for catching errors early and preventing the script from continuing to execute in an erroneous state.

-u: This option treats unset variables as an error and causes the script to exit immediately if an unset variable is encountered. This helps in identifying and handling cases where variables might not have been initialized properly.

-v: This option makes the shell print each command to the standard error output before executing it. This is useful for debugging purposes, as it allows you to see the exact commands being run.

-x: This option makes the shell print each command to the standard error output after expanding it but before executing it. This provides a detailed trace of the script's execution, which is helpful for debugging complex scripts.

In summary, the shebang line #!/bin/bash -euvx sets up the script to be executed with Bash and enables several options that enhance error handling and debugging capabilities. This setup is particularly useful during the development and testing phases of a project, as it helps to quickly identify and resolve issues within the script.

As the code is already mature, it doesn't requires any debugging options.
Going to replace <#!/bin/bash -euvx> with <#!/bin/bash>