### PR TITLE
Adding fix in qm cleanup for disk tests

### DIFF
--- a/tests/ffi/disk/test.sh
+++ b/tests/ffi/disk/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -euvx
+#!/bin/bash -evx
 
 # shellcheck disable=SC1091
 
@@ -36,5 +36,6 @@ fi
 
 ls -lh /root/file.lock
 
-disk_cleanup
-
+# Calling cleanup QM directorly to workaround exit code once
+# /var/qm disk is full.
+podman exec -it qm /bin/bash -c 'podman  rmi -i -f --all; echo $?'


### PR DESCRIPTION
During the work of post install /var/qm partition
podman rmi throws error of full diskspace on cleanup,
This error fails the test on SoC HiL