### PR TITLE
imporve the cleanup steps

### DIFF
--- a/tests/ffi/qm-oom-score-adj/test.sh
+++ b/tests/ffi/qm-oom-score-adj/test.sh
@@ -17,8 +17,9 @@
 . ../common/prepare.sh
 
 disk_cleanup
-prepare_images
+prepare_test
 reload_config
+prepare_images
 
 # Function to retrieve the PID with retries for a container
 get_pid_with_retries() {


### PR DESCRIPTION
 Run qm-oom-score-adj alone it will pass, but if run it with other test cases (under /tests/ffi), it will fail.
 So improved the cleanup steps.
 resolve https://github.com/containers/qm/issues/576