### PR TITLE
qm.if: allow kvm connectto unix_stream_socket

### DIFF
--- a/qm.if
+++ b/qm.if
@@ -363,7 +363,7 @@ template(`qm_domain_template',`
 	manage_sock_files_pattern($1_container_kvm_t, $1_file_t, $1_file_t)
 
 	allow $1_container_kvm_t $1_container_wayland_t:unix_stream_socket rw_stream_socket_perms;
-	allow $1_container_kvm_t $1_t:unix_stream_socket rw_stream_socket_perms;
+	allow $1_container_kvm_t $1_t:unix_stream_socket { connectto rw_stream_socket_perms };
 	container_stream_connect($1_container_kvm_t)
 
 	allow $1_container_kvm_t $1_t:tun_socket attach_queue;


### PR DESCRIPTION
This rule covers the ase of a qm_container_kvm_t
container (e.g., containerized qemu) to work
with dbus display.

Also covers the usecase for vhost-user devices,
as they use unix sockets to communicate with the
VMM (that is, assuming they also use the
qm_container_kvm_t type label).