### PR TITLE
Add Fedora 41 and drop Fedora 38 from Packit config

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -112,9 +112,9 @@ jobs:
     update_release: false
     dist_git_branches:
       - fedora-rawhide
+      - fedora-41
       - fedora-40
       - fedora-39
-      - fedora-38
       - epel-9
       - epel-10
 
@@ -122,9 +122,9 @@ jobs:
     trigger: commit
     dist_git_branches:
       - fedora-rawhide
+      - fedora-41
       - fedora-40
       - fedora-39
-      - fedora-38
       - epel-9
       - epel-10
 
@@ -132,8 +132,8 @@ jobs:
     trigger: commit
     dist_git_branches:
       # rawhide updates are created automatically
+      - fedora-41
       - fedora-40
       - fedora-39
-      - fedora-38
       - epel-9
       - epel-10


### PR DESCRIPTION
Is there a reason why you don't want to use aliases such as `fedora-all`, `fedora-branched` or `epel-all`?