### PR TITLE
qm sub-package qm_dropin_mount_bind_input

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,7 @@ rpm: clean dist ##             - Creates a local RPM package, useful for develop
 	rpmbuild -ba \
 		--define="enable_qm_dropin_img_tempdir 0" \
 		--define="enable_qm_mount_bind_tty7 0" \
+		--define="enable_qm_mount_bind_input 0" \
 		--define="_topdir ${RPM_TOPDIR}" \
 		--define="version ${VERSION}" \
 		${SPECFILE}
@@ -81,6 +82,12 @@ qm_dropin_img_tempdir: ##            - Creates a QM RPM sub-package qm_dropin_im
 qm_dropin_mount_bind_tty7: ##        - Creates a QM RPM sub-package to mount bind /dev/tty7 in the nested containers
 	sed -i 's/%define enable_qm_mount_bind_tty7 0/%define enable_qm_mount_bind_tty7 1/' ${SPECFILE}
 	sed -i 's/^Version:.*/Version: ${VERSION}/' ${SPECFILE}
+	$(MAKE) VERSION=${VERSION} rpm
+
+.PHONY: qm_dropin_mount_bind_input
+qm_dropin_mount_bind_input: ##       - Creates a QM RPM sub-package to mount bind input in the nested containers
+	sed -i 's/%define enable_qm_mount_bind_input 0/%define enable_qm_mount_bind_input 1/' ${SPECFILE}
+	tools/version-update -v ${VERSION}
 	$(MAKE) VERSION=${VERSION} rpm
 
 install-policy: all ##             - Install selinux policies only

--- a/etc/qm/containers/containers.conf.d/qm_dropin_mount_bind_input.conf
+++ b/etc/qm/containers/containers.conf.d/qm_dropin_mount_bind_input.conf
@@ -1,0 +1,47 @@
+# Drop-in configuration for Podman to mount bind /dev/input from host to container
+#
+# Input Device Nodes
+# ========================
+# The files inside /dev/input are typically character device nodes that
+# correspond to input hardware such:
+#
+# - Keyboards
+# - Mice
+# - Touchpads
+# - Joysticks
+# - Multimedia keys
+# - Device files like /dev/input/event0, /dev/input/event1, etc., represent
+#   different input events from connected devices.
+#
+# Event Interface
+# ==================
+# The Linux kernel uses an event-based input system where all user-space
+# programs interact with devices via event nodes (/dev/input/event*).
+# Each input device (keyboard, mouse, etc.) is associated with an event
+# node that captures raw input events, such as key presses, mouse movs, etc.
+#
+# Programs or services can read input events by opening these device nodes
+# and processing the input in real-time.
+#
+# Types of Devices in /dev/input
+# ================================
+# /dev/input/mice: All mice input, providing a unified interface
+# for all attached mice.
+#
+# /dev/input/js0, /dev/input/js1: Joystick devices that represent
+# individual game controllers.
+#
+# /dev/input/eventX: Event files where X is a number corresponding to
+# each input device's unique event file.
+#
+# /dev/input/by-id/: Symbolic links to input devices based on their
+# unique hardware ID.
+#
+# /dev/input/by-path/: Symbolic links based on the physical path the
+# input device is connected to (useful for distinguishing between
+# identical devices connected to different ports).
+#
+[containers]
+devices = [
+	"/dev/input:/dev/input"
+]


### PR DESCRIPTION
QM sub-package qm_dropin_mount_bind_input will configure via drop-in /dev/input to allow nested containers to automatically see devices like: Keyboards, Mice, Touchpads, Joysticks, Multimedia keys and Device files like /dev/input/event0, /dev/input/event1, etc.

Just execute: make qm_dropin_mount_bind_input