### PR TITLE
Update Fedora and EPEL branch targets to architecture-specific branches in .packit.yaml

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -111,29 +111,30 @@ jobs:
     trigger: release
     update_release: false
     dist_git_branches:
-      - fedora-rawhide
-      - fedora-41
-      - fedora-40
-      - fedora-39
-      - epel-9
-      - epel-10
+      - fedora-all-aarch64
+      - fedora-all-ppc64le
+      - fedora-all-x86_64
+      - epel-all-aarch64
+      - epel-all-ppc64le
+      - epel-all-x86_64
 
   - job: koji_build
     trigger: commit
     dist_git_branches:
-      - fedora-rawhide
-      - fedora-41
-      - fedora-40
-      - fedora-39
-      - epel-9
-      - epel-10
+      - fedora-all-aarch64
+      - fedora-all-ppc64le
+      - fedora-all-x86_64
+      - epel-all-aarch64
+      - epel-all-ppc64le
+      - epel-all-x86_64
 
   - job: bodhi_update
     trigger: commit
     dist_git_branches:
       # rawhide updates are created automatically
-      - fedora-41
-      - fedora-40
-      - fedora-39
-      - epel-9
-      - epel-10
+      - fedora-all-aarch64
+      - fedora-all-ppc64le
+      - fedora-all-x86_64
+      - epel-all-aarch64
+      - epel-all-ppc64le
+      - epel-all-x86_64


### PR DESCRIPTION
This merge request updates the `.packit.yaml` configuration file to replace the existing Fedora and EPEL branch targets with architecture-specific branches for aarch64, ppc64le, and x86_64. The updated branches ensure that builds are now targeted for the respective architectures.

### Changes:
- Updated Fedora branch targets from `fedora-rawhide`, `fedora-41`, `fedora-40`, and `fedora-39` to `fedora-all-aarch64`, `fedora-all-ppc64le`, and `fedora-all-x86_64`.
- Updated EPEL branch targets from `epel-9` and `epel-10` to `epel-all-aarch64`, `epel-all-ppc64le`, and `epel-all-x86_64`.

These changes align the branch targets with architecture-specific builds to improve accuracy in handling package distribution for different systems.
