### PR TITLE
qm sub-package qm_dropin_mount_bind_ttyUSB0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,7 @@ rpm: clean dist ##             - Creates a local RPM package, useful for develop
 	rpmbuild -ba \
 		--define="enable_qm_dropin_img_tempdir 0" \
 		--define="enable_qm_mount_bind_tty7 0" \
+		--define="enable_qm_mount_bind_ttyUSB0 0" \
 		--define="enable_qm_mount_bind_input 0" \
 		--define="_topdir ${RPM_TOPDIR}" \
 		--define="version ${VERSION}" \
@@ -75,6 +76,12 @@ ostree: qm_dropin_img_tempdir ##             - A helper for creating QM packages
 .PHONY: qm_dropin_img_tempdir
 qm_dropin_img_tempdir: ##            - Creates a QM RPM sub-package qm_dropin_img_tempdir
 	sed -i 's/%define enable_qm_dropin_img_tempdir 0/%define enable_qm_dropin_img_tempdir 1/' ${SPECFILE}
+	tools/version-update -v ${VERSION}
+	$(MAKE) VERSION=${VERSION} rpm
+
+.PHONY: qm_dropin_mount_bind_ttyUSB0
+qm_dropin_mount_bind_ttyUSB0: ##     - Creates a QM RPM sub-package to mount bind /dev/ttyUSB0 in the nested containers
+	sed -i 's/%define enable_qm_mount_bind_ttyUSB0 0/%define enable_qm_mount_bind_ttyUSB0 1/' ${SPECFILE}
 	tools/version-update -v ${VERSION}
 	$(MAKE) VERSION=${VERSION} rpm
 

--- a/etc/qm/containers/containers.conf.d/qm_dropin_mount_bind_ttyUSB0.conf
+++ b/etc/qm/containers/containers.conf.d/qm_dropin_mount_bind_ttyUSB0.conf
@@ -1,0 +1,74 @@
+# Drop-in configuration for Podman to mount bind /dev/ttyUSB0 from host to QM
+# Containers.
+#
+# USB (Universal Serial Bus) can be used in two main modes: as a standard USB
+# device or for serial communication.
+#
+# 1. USB as a Standard Device
+#    -------------------------
+#    Most USB devices (e.g., flash drives, keyboards, mice) communicate using
+#    the USB protocol. These devices use their own drivers and are typically
+#    represented by device files such as /dev/sda for storage devices, or
+#    /dev/input/ for input devices. Standard USB devices offer high data
+#    transfer rates and advanced features like plug-and-play.
+#
+# 2. USB for Serial Communication
+#    -----------------------------
+#    USB can also be used to emulate traditional serial communication (e.g., RS-232).
+#    This is common when using USB-to-serial adapters or devices like OBDII
+#    (On-Board Diagnostics) interfaces, which convert vehicle diagnostic information
+#    from the OBDII port to serial, then to USB, allowing the computer to read the data.
+#    In this case, Linux creates device files like /dev/ttyUSB0 or /dev/ttyUSB1,
+#    which represent virtual serial ports. These ports allow software to interact
+#    with the OBDII device as if it were using a classic serial connection.
+#
+#    Please NOTE
+#    ------------
+#    You can find ready-made ELM327 OBD2 (Serial) to USB cables available for
+#    purchase, so there’s no need to build one from scratch unless you really want to.
+#    Just make sure that the cable is compatible with your vehicle's manufacturer.
+#
+#
+# 3. ASCII Diagram
+#    -------------
+#    See below an ASCII diagram to show ELM327 cable connected into OBDII Diagnostic
+#    Port and USB computer port and shared to QM container and it's nested containers.
+#
+#      +----------------------------------+
+#      |              Vehicle             |
+#      |  +----------+                    |
+#      |  | OBDII     |                   | The Vehicle OBDII Diagnostic Port is
+#      |  | Diagnostic|                   | usually *under the dashboard* near the
+#      |  | Port      |                   | the driver's seat.
+#      |  +-----+-----+                   |
+#      |        |                         |
+#      +----------------------------------+
+#               |
+#               |     ELM327 Cable (OBDII to USB)
+#               +----------------------------------+
+#                                                  |
+#                                                  v
+#      +------------------------------------------------------------+
+#      |                          Laptop Machine                    |
+#      |                                                            |
+#      |   /dev/ttyUSB0 <-- USB device for ELM327                   |
+#      |                                                            |
+#      |   +-----------------------------------------+              |
+#      |   |                 QM Container            |              |
+#      |   |                                         |              |
+#      |   |   /dev/ttyUSB0 <-- Shared USB device    |              |
+#      |   |                                         |              |
+#      |   |   +-----------------------------+       |              |
+#      |   |   |  Nested Container           |       |              |
+#      |   |   |                             |       |              |
+#      |   |   |   /dev/ttyUSB0 <-- Shared   |       |              |
+#      |   |   |      USB device             |       |              |
+#      |   |   +-----------------------------+       |              |
+#      |   +-----------------------------------------+              |
+#      +------------------------------------------------------------+
+#
+#
+[containers]
+devices = [
+	"/dev/ttyUSB0:/dev/ttyUSB0"
+]

--- a/rpm/qm.spec
+++ b/rpm/qm.spec
@@ -21,6 +21,12 @@
 # it usually runs on this virtual console.
 %define enable_qm_mount_bind_tty7 0
 
+
+###########################################
+# subpackage QM - mount bind /dev/ttyUSB0 #
+###########################################
+%define enable_qm_mount_bind_ttyUSB0 0
+
 ###########################################
 # subpackage QM - input devices           #
 ###########################################
@@ -128,6 +134,22 @@ install -d %{buildroot}%{_sysconfdir}/qm/containers/containers.conf.d
 %endif
 ########################################################
 # END - qm dropin sub-package - img tempdir            #
+########################################################
+
+########################################################
+# START - qm dropin sub-package - mount ttyUSB0        #
+########################################################
+%if %{enable_qm_mount_bind_ttyUSB0}
+    # first step - add drop-in file in /etc/containers/containers.d.conf/qm_dropin_mount_bind_ttyUSB0.conf
+    # to QM container mount ttyUSB0
+    install -m 644 %{_builddir}/qm-%{version}/etc/qm/containers/containers.conf.d/qm_dropin_mount_bind_ttyUSB0.conf %{buildroot}%{_sysconfdir}/containers/containers.conf.d/qm_dropin_mount_bind_ttyUSB0.conf
+
+    # second step - add drop-in file in /etc/qm/containers/containers.d.conf/qm_dropin/mount_bind_ttyUSB0.conf
+    # to nested containers in QM env mount bind ttyUSB0
+    install -m 644 %{_builddir}/qm-%{version}/etc/qm/containers/containers.conf.d/qm_dropin_mount_bind_ttyUSB0.conf %{buildroot}%{_sysconfdir}/qm/containers/containers.conf.d/qm_dropin_mount_bind_ttyUSB0.conf
+%endif
+########################################################
+# END - qm dropin sub-package - mount ttyUSB0          #
 ########################################################
 
 ########################################################
@@ -272,6 +294,25 @@ additional drop-in configurations.
 %files -n qm_mount_bind_input
 %{_sysconfdir}/containers/containers.conf.d/qm_dropin_mount_bind_input.conf
 %{_sysconfdir}/qm/containers/containers.conf.d/qm_dropin_mount_bind_input.conf
+%endif
+
+#######################################
+# sub-package QM Mount ttyUSB0        #
+#######################################
+%if %{enable_qm_mount_bind_ttyUSB0}
+%package -n qm_mount_bind_ttyUSB0
+Summary: Drop-in configuration for QM containers to mount bind ttyUSB0
+Requires: %{name} = %{version}-%{release}
+BuildArch: noarch
+
+%description -n qm_mount_bind_ttyUSB0
+This sub-package installs a drop-in configurations for the QM.
+It creates the `/etc/qm/containers/containers.conf.d/` directory for adding
+additional drop-in configurations.
+
+%files -n qm_mount_bind_ttyUSB0
+%{_sysconfdir}/containers/containers.conf.d/qm_dropin_mount_bind_ttyUSB0.conf
+%{_sysconfdir}/qm/containers/containers.conf.d/qm_dropin_mount_bind_ttyUSB0.conf
 %endif
 
 #######################################


### PR DESCRIPTION
Another ready to use example in-tree to users.
Execute: make qm_dropin_mount_bind_ttyUSB0 and voi-la.