### PR TITLE
Remove -e from set-ffi-env-e2e

### DIFF
--- a/tests/e2e/set-ffi-env-e2e
+++ b/tests/e2e/set-ffi-env-e2e
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -eoux pipefail
+set -oux pipefail
 
 # shellcheck disable=SC1091
 #


### PR DESCRIPTION
It fails script on non c9s distros