### PR TITLE
makefile: update version in rpm target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,7 @@ dist: ##             - Creates the QM distribution package
 .PHONY: rpm
 rpm: clean dist ##             - Creates a local RPM package, useful for development
 	mkdir -p ${RPM_TOPDIR}/{RPMS,SRPMS,BUILD,SOURCES}
+	tools/version-update -v ${VERSION}
 	cp ./rpm/v${VERSION}.tar.gz ${RPM_TOPDIR}/SOURCES
 	rpmbuild -ba \
 		--define="enable_qm_dropin_img_tempdir 0" \
@@ -77,31 +78,26 @@ ostree: qm_dropin_img_tempdir ##             - A helper for creating QM packages
 .PHONY: qm_dropin_img_tempdir
 qm_dropin_img_tempdir: ##            - Creates a QM RPM sub-package qm_dropin_img_tempdir
 	sed -i 's/%define enable_qm_dropin_img_tempdir 0/%define enable_qm_dropin_img_tempdir 1/' ${SPECFILE}
-	tools/version-update -v ${VERSION}
 	$(MAKE) VERSION=${VERSION} rpm
 
 .PHONY: qm_dropin_mount_bind_ttyUSB0
 qm_dropin_mount_bind_ttyUSB0: ##     - Creates a QM RPM sub-package to mount bind /dev/ttyUSB0 in the nested containers
 	sed -i 's/%define enable_qm_mount_bind_ttyUSB0 0/%define enable_qm_mount_bind_ttyUSB0 1/' ${SPECFILE}
-	tools/version-update -v ${VERSION}
 	$(MAKE) VERSION=${VERSION} rpm
 
 .PHONY: qm_dropin_mount_bind_sound
 qm_dropin_mount_bind_sound: ##       - Creates a QM RPM sub-package to mount bind /dev/snd in the nested containers
 	sed -i 's/%define enable_qm_mount_bind_sound 0/%define enable_qm_mount_bind_sound 1/' ${SPECFILE}
-	tools/version-update -v ${VERSION}
 	$(MAKE) VERSION=${VERSION} rpm
 
 .PHONY: qm_dropin_mount_bind_tty7
 qm_dropin_mount_bind_tty7: ##        - Creates a QM RPM sub-package to mount bind /dev/tty7 in the nested containers
 	sed -i 's/%define enable_qm_mount_bind_tty7 0/%define enable_qm_mount_bind_tty7 1/' ${SPECFILE}
-	tools/version-update -v ${VERSION}
 	$(MAKE) VERSION=${VERSION} rpm
 
 .PHONY: qm_dropin_mount_bind_input
 qm_dropin_mount_bind_input: ##       - Creates a QM RPM sub-package to mount bind /dev/input in the nested containers
 	sed -i 's/%define enable_qm_mount_bind_input 0/%define enable_qm_mount_bind_input 1/' ${SPECFILE}
-	tools/version-update -v ${VERSION}
 	$(MAKE) VERSION=${VERSION} rpm
 
 install-policy: all ##             - Install selinux policies only

--- a/docs/devel/README.md
+++ b/docs/devel/README.md
@@ -26,20 +26,11 @@ especially for testing new features before submitting a pull request.
 git clone https://github.com/containers/qm.git
 ```
 
-**2.** Change the Version macro in the spec file
+**2.** Build the RPM
 
-Set the QM version to a higher number from the current one.
+Select a QM version that is a higher number from the current one.
 For example, if today's QM version is 0.6.2, set it to 1.0 so that
 the RPM created is identifiable as yours.
-
-You can use the `version-update` tool available in the project to perform
-the changes required to update to the new version (1.0):
-
-```bash
-./tools/version-update -v 1.0
-```
-
-**3.** Build the RPM
 
 ```bash
 make clean && VERSION=1.0 make rpm


### PR DESCRIPTION
Call the update-version script from the
rpm target in the makefile and remove it
from all the subpackage targets, so that
we have a single point of failure and
avoid code repetition.