### PR TITLE
Adding VARIABLES for subpackages build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,66 @@ SPECFILE=rpm/qm.spec
 RPM_TOPDIR ?= $(PWD)/rpmbuild
 VERSION ?= $(shell cat VERSION)
 
+###########################################
+# subpackage QM - img_tempdir             #
+###########################################
+# use img temp dir as /var/tmp            #
+###########################################
+# export EN_QM_DROP_IMG_TMPDIR=1
+EN_QM_DROP_IMG_TMPDIR ?= 0
+
+#######################################################################
+# subpackage QM - mount bind /dev/tty7                                #
+#######################################################################
+# mount bind /dev/tty7 from host to nested containers as /dev/tty7:rw #
+# Please note: /dev/tty7 is typically the virtual terminal associated #
+# with the graphical user interface (GUI) on Linux systems.           #
+# It is where the X server or the Wayland display server usually runs,#
+# handling the graphical display, input, and windowing environment.   #
+# When you start a graphical session (such as GNOME, KDE, etc.),      #
+# it usually runs on this virtual console.                            #
+#######################################################################
+# export EN_QM_MNT_BIND_TTY7=1
+EN_QM_MNT_BIND_TTY7 ?= 0
+
+############################################
+# subpackage QM - mount bind audio device  #
+# from host to container and nested        #
+# container enabling sound                 #
+############################################
+# export EN_QM_MNT_BIND_SOUND=1
+EN_QM_MNT_BIND_SOUND ?= 0
+
+###########################################
+# subpackage QM - Enable Window Manager   #
+###########################################
+# export EN_QM_WINDOW_MGR=1
+EN_QM_WINDOW_MGR ?= 0
+
+###########################################
+# subpackage QM - mount bind /dev/ttyUSB0 #
+###########################################
+# export EN_QM_MNT_BIND_TTY_USB=1
+EN_QM_MNT_BIND_TTY_USB ?= 0
+
+###########################################
+# subpackage QM - mount bind /dev/kvm #
+###########################################
+# export EN_QM_MNT_BIND_KVM=1
+EN_QM_MNT_BIND_KVM ?= 0
+
+###########################################
+# subpackage QM - input devices           #
+###########################################
+# export EN_QM_MNT_BIND_INPUT=1
+EN_QM_MNT_BIND_INPUT ?= 0
+
+###########################################
+# subpackage QM - input video             #
+###########################################
+# export EN_QM_MNT_BIND_VIDEO=1
+EN_QM_MNT_BIND_VIDEO ?= 0
+
 # Default help target
 .PHONY: help
 help:
@@ -62,13 +122,14 @@ rpm: clean dist ##             - Creates a local RPM package, useful for develop
 	tools/version-update -v ${VERSION}
 	cp ./rpm/v${VERSION}.tar.gz ${RPM_TOPDIR}/SOURCES
 	rpmbuild -ba \
-		--define="enable_qm_dropin_img_tempdir 0" \
-		--define="enable_qm_mount_bind_tty7 0" \
-		--define="enable_qm_mount_bind_ttyUSB0 0" \
-		--define="enable_qm_mount_bind_sound 0" \
-		--define="enable_qm_mount_bind_kvm 0" \
-		--define="enable_qm_mount_bind_input 0" \
-		--define="enable_qm_mount_bind_video 0" \
+		--define="u_enable_qm_dropin_img_tempdir ${EN_QM_DROP_IMG_TMPDIR}" \
+		--define="u_enable_qm_window_manager ${EN_QM_WINDOW_MGR}" \
+		--define="u_enable_qm_mount_bind_tty7 ${EN_QM_MNT_BIND_TTY7}" \
+		--define="u_enable_qm_mount_bind_ttyUSB0 ${EN_QM_MNT_BIND_TTY_USB}" \
+		--define="u_enable_qm_mount_bind_sound ${EN_QM_MNT_BIND_SOUND}" \
+		--define="u_enable_qm_mount_bind_kvm ${EN_QM_MNT_BIND_KVM}" \
+		--define="u_enable_qm_mount_bind_input ${EN_QM_MNT_BIND_INPUT}" \
+                --define="u_enable_qm_mount_bind_video ${EN_QM_MNT_BIND_VIDEO}"
 		--define="_topdir ${RPM_TOPDIR}" \
 		--define="version ${VERSION}" \
 		${SPECFILE}

--- a/docs/devel/README.md
+++ b/docs/devel/README.md
@@ -20,13 +20,19 @@
 Building QM locally with changes for tests is a recommended practice,
 especially for testing new features before submitting a pull request.
 
-**1.** Clone the repo
+**1.** Prerequisite
+
+```bash
+dnf install -y rpm-build golang-github-cpuguy83-md2man selinux-policy-devel
+```
+
+**2.** Clone the repo
 
 ```bash
 git clone https://github.com/containers/qm.git
 ```
 
-**2.** Build the RPM
+**3.** Build the RPM
 
 Select a QM version that is a higher number from the current one.
 For example, if today's QM version is 0.6.2, set it to 1.0 so that
@@ -71,7 +77,7 @@ cd /root/rpmbuild/RPMS/
 createrepo .
 ```
 
-**3.** Clone the CentOS Automotive distro for the build
+**4.** Clone the CentOS Automotive distro for the build
 
 Ensure you meet the requirements for the CentOS Automotive Stream by
 referring to [this link](https://sigs.centos.org/automotive/building/).

--- a/rpm/qm.spec
+++ b/rpm/qm.spec
@@ -11,51 +11,56 @@
 # subpackage QM - img_tempdir             #
 ###########################################
 # use img temp dir as /var/tmp
-%define enable_qm_dropin_img_tempdir 0
+%define enable_qm_dropin_img_tempdir 0%{?u_enable_qm_dropin_img_tempdir}
 
-###########################################
-# subpackage QM - mount bind /dev/tty7    #
-###########################################
-# mount bind /dev/tty7 from host to nested containers as /dev/tty7:rw
-# Please note: /dev/tty7 is typically the virtual terminal associated
-# with the graphical user interface (GUI) on Linux systems.
-# It is where the X server or the Wayland display server usually runs,
-# handling the graphical display, input, and windowing environment.
-# When you start a graphical session (such as GNOME, KDE, etc.),
-# it usually runs on this virtual console.
-%define enable_qm_mount_bind_tty7 0
+####################################################################
+# subpackage QM - mount bind /dev/tty7                             #
+####################################################################
+# mount bind /dev/tty7 from host to nested containers              #
+# as /dev/tty7:rw                                                  #
+# Please note:                                                     #
+# /dev/tty7 is typically the virtual terminal                      #
+# associated with the graphical user interface (GUI)               #
+# on Linux systems.                                                #
+# It is where the X server or the Wayland display server           #
+# usually runs, handling the graphical display, input              #
+# and windowing environment.                                       #
+# When you start a graphical session (ex. GNOME, KDE, etc.),       #
+# it usually runs on this virtual console.                         #
+####################################################################
+%define enable_qm_mount_bind_tty7 0%{?u_enable_qm_mount_bind_tty7}
 
-#######################################################################
-# subpackage QM - mount bind audio device from host to container and  #
-# nested container enabling sound                                     #
-#######################################################################
-%define enable_qm_mount_bind_sound 0
+#####################################################################
+# subpackage QM - mount bind audio                                  #
+# device from host to container and nested container enabling sound #
+#####################################################################
+%define enable_qm_mount_bind_sound 0%{?u_enable_qm_mount_bind_sound}
 
 
 ###########################################
 # subpackage QM - Enable Window Manager   #
 ###########################################
-%define enable_qm_window_manager 0
+%define enable_qm_window_manager 0%{?u_enable_qm_window_manager}
 
 ###########################################
 # subpackage QM - mount bind /dev/ttyUSB0 #
 ###########################################
-%define enable_qm_mount_bind_ttyUSB0 0
+%define enable_qm_mount_bind_ttyUSB0 0%{?u_enable_qm_mount_bind_ttyUSB0}
 
 ###########################################
-# subpackage QM - mount bind /dev/kvm #
+# subpackage QM - mount bind /dev/kvm     #
 ###########################################
-%define enable_qm_mount_bind_kvm 0
+%define enable_qm_mount_bind_kvm 0%{?u_enable_qm_mount_bind_kvm}
 
 ###########################################
 # subpackage QM - mount bind /dev/video   #
 ###########################################
-%define enable_qm_mount_bind_video 0
+%define enable_qm_mount_bind_video 0%{?u_enable_qm_mount_bind_video}
 
 ###########################################
 # subpackage QM - input devices           #
 ###########################################
-%define enable_qm_mount_bind_input 0
+%define enable_qm_mount_bind_input 0%{?u_enable_qm_mount_bind_input}
 
 # Some bits borrowed from the openstack-selinux package
 %global selinuxtype targeted


### PR DESCRIPTION
Adding support in build env vars 

This set rpmbuild --define vars in Makefile. 
remove define vats for building subpackages

Toggle package to build by define export variable=1
