### PR TITLE
add support for tmt prune

### DIFF
--- a/tests/ffi/main.fmf
+++ b/tests/ffi/main.fmf
@@ -1,0 +1,8 @@
+/:
+    inherit: false
+
+require:
+  - type: file
+    pattern:
+      - /tests/e2e/lib/utils
+      - /tests/ffi/common/prepare.sh


### PR DESCRIPTION
When using tmt `prune` (Copy only immediate directories of executed tests and their required files. Added in version 1.29.) in the test plan, need to specify the location of the included file, otherwise an error will occur.