### PR TITLE
Add qm-is-ostree script installation and RPM packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,3 +130,4 @@ install: man all ##             - Install QM files (including selinux)
 	install -D -m 644 qm_file_contexts ${DESTDIR}${DATADIR}/qm/file_contexts
 	install -D -m 644 containers.conf ${DESTDIR}${DATADIR}/qm/containers.conf
 	install -D -m 644 qm.container ${DESTDIR}${DATADIR}/containers/systemd/qm.container
+	install -D -m 755 tools/comment-tz-local ${DESTDIR}${DATADIR}/qm/qm-is-ostree

--- a/Makefile
+++ b/Makefile
@@ -130,4 +130,4 @@ install: man all ##             - Install QM files (including selinux)
 	install -D -m 644 qm_file_contexts ${DESTDIR}${DATADIR}/qm/file_contexts
 	install -D -m 644 containers.conf ${DESTDIR}${DATADIR}/qm/containers.conf
 	install -D -m 644 qm.container ${DESTDIR}${DATADIR}/containers/systemd/qm.container
-	install -D -m 755 tools/comment-tz-local ${DESTDIR}${DATADIR}/qm/qm-is-ostree
+	install -D -m 755 tools/qm-is-ostree ${DESTDIR}${DATADIR}/qm/qm-is-ostree

--- a/rpm/qm.spec
+++ b/rpm/qm.spec
@@ -292,6 +292,7 @@ install -d %{buildroot}%{_sysconfdir}/qm/containers/containers.conf.d
 # Execute the script to create seccomp rules after the package is installed
 /usr/share/qm/create-seccomp-rules
 /usr/share/qm/comment-tz-local # FIX-ME GH-issue: 367
+/usr/share/qm/qm-is-ostree
 
 %preun
 if [ $1 = 0 ]; then
@@ -328,6 +329,7 @@ fi
 %{_datadir}/qm/qm-rootfs
 %{_datadir}/qm/qm-storage-settings
 %{_datadir}/qm/comment-tz-local
+%{_datadir}/qm/qm-is-ostree
 %ghost %dir %{_datadir}/containers
 %ghost %dir %{_datadir}/containers/systemd
 %{_datadir}/containers/systemd/qm.container

--- a/tools/qm-is-ostree
+++ b/tools/qm-is-ostree
@@ -1,0 +1,34 @@
+#!/bin/bash
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+# Simple tool to check if the system is running under OSTree
+# Determines if the system is using OSTree by checking for the
+# existence of the directory /run/ostree
+# Returns:
+# 0 (success) if the directory path exists, indicating the system is
+# running under OSTree.
+# 1 (failure) if the directory does not exist, indicating the
+# system is not running under OSTree
+
+OSTREE_PATH="/run/ostree"
+
+if [ -d "${OSTREE_PATH}" ] || command -v ostree >/dev/null 2>&1; then
+    echo "QM is running on an OSTree-based system."
+    exit 0
+else
+    echo "QM is not running on an OSTree-based system."
+    exit 1
+fi


### PR DESCRIPTION
- Updated Makefile to install the qm-is-ostree script to ${DATADIR}/qm/
- Modified qm.spec to include qm-is-ostree in the install and package files
- Added the qm-is-ostree script to the RPM pre uninstall steps
Signed-off-by: Rakesh Musalay <rmusalay@redhat.com>

Address the issue https://github.com/containers/qm/issues/586
Summary of Changes
Makefile Updates:

Added a new installation step for the qm-is-ostree script.
The script tools/qm-is-ostree is installed as qm-is-ostree with executable permissions (755) to the target directory ${DATADIR}/qm/.

RPM Spec File (qm.spec) Modifications:

Added an entry to install the qm-is-ostree script in the %install section at /usr/share/qm/qm-is-ostree.
Updated the list of packaged files to include %{_datadir}/qm/qm-is-ostree, ensuring the script is tracked as part of the package.
Added the new script qm-is-ostree to the %preun section, indicating that it may be involved in uninstallation steps.