### PR TITLE
qm subpackage: simulate car cameras using OSS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,7 @@ rpm: clean dist ##             - Creates a local RPM package, useful for develop
 		--define="enable_qm_mount_bind_sound 0" \
 		--define="enable_qm_mount_bind_kvm 0" \
 		--define="enable_qm_mount_bind_input 0" \
+		--define="enable_qm_mount_bind_video 0" \
 		--define="_topdir ${RPM_TOPDIR}" \
 		--define="version ${VERSION}" \
 		${SPECFILE}
@@ -89,6 +90,11 @@ qm_dropin_img_tempdir: ##            - QM RPM sub-package qm_dropin_img_tempdir
 .PHONY: qm_dropin_mount_bind_ttyUSB0
 qm_dropin_mount_bind_ttyUSB0: ##     - QM RPM sub-package to mount bind /dev/ttyUSB0 in the nested containers
 	sed -i 's/%define enable_qm_mount_bind_ttyUSB0 0/%define enable_qm_mount_bind_ttyUSB0 1/' ${SPECFILE}
+	$(MAKE) VERSION=${VERSION} rpm
+
+.PHONY: qm_dropin_mount_bind_video0
+qm_dropin_mount_bind_video0: ##      - QM RPM sub-package to mount bind /dev/video0 in the nested containers
+	sed -i 's/%define enable_qm_mount_bind_video 0/%define enable_qm_mount_bind_video 1/' ${SPECFILE}
 	$(MAKE) VERSION=${VERSION} rpm
 
 .PHONY: qm_dropin_mount_bind_kvm

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
     - [Creating your own drop-in QM sub-package](Creating-your-own-drop-in-QM-sub-package)
     - [QM sub-package kvm](QM-sub-package-kvm)
     - [QM sub-package Sound](QM-sub-package-Sound)
+    - [QM sub-package Video](QM-sub-package-Video)
 3. [SELinux Policy](#selinux-policy)
 4. [BlueChi](#bluechi)
 5. [RPM building dependencies](#rpm-building-dependencies)
@@ -153,6 +154,41 @@ sudo podman restart qm
 ```bash
 sudo rpm -e qm_mount_bind_input
 ```
+
+## QM sub-package Video
+
+The video sub-package exposes `/dev/video0` (or many video devices required) to the container. This feature is useful for demonstrating how to share a camera from the host system into a container using Podman drop-in. To showcase this functionality, we provide the following demo:
+
+### Building the video sub-package, installing, and restarting QM
+
+```bash
+host> make qm_dropin_mount_bind_video0
+host> sudo podman restart qm
+host> sudo dnf install ./rpmbuild/RPMS/noarch/qm_mount_bind_video-0.6.7-1.fc40.noarch.rpm
+```
+
+This simulates a rear camera when the user shifts into reverse gear.
+
+In this simulation, we created a systemd service that, every time it is started, captures a snapshot from the webcam, simulating the action of a rear camera. (Feel free to start and restart the service multiple times!)
+
+```bash
+host> sudo podman exec -it qm bash
+
+bash-5.2# systemctl daemon-reload
+bash-5.2# systemctl start rear-camera
+
+# ls -la /tmp/screenshot.jpg
+-rw-r--r--. 1 root root 516687 Oct 13 04:05 /tmp/screenshot.jpg
+bash-5.2#
+```
+
+### Copy the screenshot to the host and view it
+
+```bash
+host> sudo podman cp qm:/tmp/screenshot.jpg .
+```
+
+Great job! Now imagine all the possibilities this opens up!
 
 ## QM sub-package Sound
 

--- a/etc/containers/systemd/ContainerFile.rear-camera
+++ b/etc/containers/systemd/ContainerFile.rear-camera
@@ -1,0 +1,15 @@
+# ContainerFile used to create the image available at quay.io/qm-images/multimedia:latest
+#
+# How to build
+# ==================
+# podman build -t quay.io/qm-images/multimedia:latest -f ContainerFile
+#
+FROM fedora:latest
+
+# ContainerFile to install multimedia tools
+
+# Additional repos for gstreamer plugins
+RUN dnf install -y fswebcam
+
+# Set CMD to bash so you can manually run tools
+CMD ["bash"]

--- a/etc/containers/systemd/rear-camera.container
+++ b/etc/containers/systemd/rear-camera.container
@@ -1,0 +1,15 @@
+# /etc/containers/systemd/rear-camera.container - demo purpose only quadlet file
+#
+# Every time this service is started, a screenshot is triggered.
+# This simulates the effect of turning on the rear camera.
+#
+# The screenshot will be saved in the /tmp directory on the host as /tmp/screenshot.jpg.
+# To view or download the screenshot, you can access it directly from the /tmp dir.:
+#
+[Install]
+WantedBy=multi-user.target
+
+[Container]
+Image=quay.io/qm-images/multimedia:latest
+Exec=fswebcam -r 1024x768 --jpeg 100 /tmp/screenshot.jpg
+Volume=/tmp:/tmp

--- a/etc/qm/containers/containers.conf.d/qm_dropin_mount_bind_video.conf
+++ b/etc/qm/containers/containers.conf.d/qm_dropin_mount_bind_video.conf
@@ -1,0 +1,62 @@
+# Drop-in configuration for Podman to mount bind /dev/videoX cameras devices
+#
+# In a typical vehicle system, cameras are connected to the car's onboard computer via a CAN bus
+# (Controller Area Network), which transmits signals from the cameras to the car’s system for real-time
+# processing. This is commonly used for functions like parking assistance, lane-keeping, or 360-degree
+# surround-view systems.
+#
+# However, it's possible to create a simulation environment using traditional hardware and open-source
+# software, eliminating the need for actual car cameras or CAN bus integration. By using open-source
+# tools like Podman containers and video processing libraries (such as GStreamer or FFmpeg), virtual
+# cameras can be simulated. These tools allow developers to simulate the video signals typically
+# produced by physical car cameras and routed through the CAN bus.
+#
+# In this setup, virtual devices (e.g., /dev/video0, /dev/video1) are mounted into a container and can
+# provide simulated video streams that mimic real camera feeds. This allows automotive software to be
+# developed and tested in a controlled environment, replicating the behavior of car cameras without
+# needing access to the physical hardware or CAN bus.
+#
+# "/dev/video0:/dev/video0", # Front camera
+# "/dev/video1:/dev/video1", # Back camera
+#
+# "/dev/video2:/dev/video2", # Power side view mirror camera (Right)
+# "/dev/video3:/dev/video3", # Power side view mirror camera (Left)
+#
+# "/dev/video4:/dev/video4", # side car camera (Right)
+# "/dev/video5:/dev/video5"  # side car camera (Left)
+#
+#          Camera System Layout (Top-Down View)
+#
+#          ┌─────────────────────────────┐
+#          │        /dev/video0          │
+#          │      (Front Camera)         │
+#          │  Primary forward-view camera│
+#          └────────────┬────────────────┘
+#                       │
+# ┌─────────────────────┴────────────────────────────────┐
+# │              Vehicle Body (Top View)                 │
+# │                                                      │
+# │      ┌─────────────────┐   ┌─────────────────┐       │
+# │      │ /dev/video2     │   │ /dev/video3     │       │
+# │      │ (Right Mirror)  │   │ (Left Mirror)   │       │
+# │      │ Secondary camera│   │ Secondary camera│       │
+# │      └─────────────────┘   └─────────────────┘       │
+# │                                                      │
+# │      ┌─────────────────┐   ┌─────────────────┐       │
+# │      │ /dev/video4     │   │ /dev/video5     │       │
+# │      │ (Right Side)    │   │ (Left Side)     │       │
+# │      │ Side-view camera│   │ Side-view camera│       │
+# │      └─────────────────┘   └─────────────────┘       │
+# └──────────────────────────────────────────────────────┘
+#                       │
+#          ┌─────────────────────────────┐
+#          │        /dev/video1          │
+#          │       (Rear Camera)         │
+#          │   Primary rear-view camera  │
+#          └─────────────────────────────┘
+#
+#
+[containers]
+devices = [
+	"/dev/video0:/dev/video0"
+]

--- a/rpm/qm.spec
+++ b/rpm/qm.spec
@@ -48,6 +48,11 @@
 %define enable_qm_mount_bind_kvm 0
 
 ###########################################
+# subpackage QM - mount bind /dev/video   #
+###########################################
+%define enable_qm_mount_bind_video 0
+
+###########################################
 # subpackage QM - input devices           #
 ###########################################
 %define enable_qm_mount_bind_input 0
@@ -246,6 +251,25 @@ install -d %{buildroot}%{_sysconfdir}/qm/containers/containers.conf.d
 %endif
 ########################################################
 # END - qm dropin sub-package - mount ttyUSB0          #
+########################################################
+
+########################################################
+# START - qm dropin sub-package - mount video          #
+########################################################
+%if %{enable_qm_mount_bind_video}
+    mkdir -p %{buildroot}/%{rootfs_qm}/%{_sysconfdir}/containers/systemd/
+    # first step - add drop-in file in /etc/containers/containers.d.conf/qm_dropin_mount_bind_video.conf
+    # to QM container mount video
+    install -m 644 %{_builddir}/qm-%{version}/etc/qm/containers/containers.conf.d/qm_dropin_mount_bind_video.conf %{buildroot}%{_sysconfdir}/containers/containers.conf.d/qm_dropin_mount_bind_video.conf
+
+    # second step - add drop-in file in /etc/qm/containers/containers.d.conf/qm_dropin/mount_bind_video.conf
+    # to nested containers in QM env mount bind video
+    install -m 644 %{_builddir}/qm-%{version}/etc/qm/containers/containers.conf.d/qm_dropin_mount_bind_video.conf %{buildroot}%{_sysconfdir}/qm/containers/containers.conf.d/qm_dropin_mount_bind_video.conf
+
+    install -m 644 %{_builddir}/qm-%{version}/etc/containers/systemd/rear-camera.container %{buildroot}/%{rootfs_qm}/%{_sysconfdir}/containers/systemd/rear-camera.container
+%endif
+########################################################
+# END - qm dropin sub-package - mount video            #
 ########################################################
 
 ########################################################
@@ -503,6 +527,26 @@ done
 %postun windowmanager
 # Reload systemd daemon after uninstallation
 podman exec qm systemctl daemon-reload &> /dev/null
+%endif
+
+#######################################
+# sub-package QM Mount Bind /dev/video#
+#######################################
+%if %{enable_qm_mount_bind_video}
+%package -n qm_mount_bind_video
+Summary: Drop-in configuration for QM containers to mount bind /dev/video
+Requires: %{name} = %{version}-%{release}
+BuildArch: noarch
+
+%description -n qm_mount_bind_video
+This sub-package installs a drop-in configurations for the QM.
+It creates the `/etc/qm/containers/containers.conf.d/` directory for adding
+additional drop-in configurations.
+
+%files -n qm_mount_bind_video
+%{_sysconfdir}/containers/containers.conf.d/qm_dropin_mount_bind_video.conf
+%{_sysconfdir}/qm/containers/containers.conf.d/qm_dropin_mount_bind_video.conf
+%{rootfs_qm}/%{_sysconfdir}/containers/systemd/rear-camera.container
 %endif
 
 #######################################


### PR DESCRIPTION
In a typical vehicle system, cameras are connected to the car's onboard computer via a CAN bus (Controller Area Network), which transmits signals from the cameras to the car’s system for real-time processing. This is commonly used for functions like parking assistance, lane-keeping, or 360-degree surround-view systems.

However, it's possible to create a simulation environment using traditional hardware and open-source software, eliminating the need for actual car cameras or CAN bus integration. By using open-source tools like Podman containers and video processing libraries (such as GStreamer or FFmpeg), virtual cameras can be simulated. These tools allow developers to simulate the video signals typically produced by physical car cameras and routed through the CAN bus.

In this setup, virtual devices (e.g., /dev/video0, /dev/video1) are mounted into a container and can provide simulated video streams that mimic real camera feeds. This allows automotive software to be developed and tested in a controlled environment, replicating the behavior of car cameras without needing access to the physical hardware or CAN bus.

To use:
```
qm> make qm_dropin_mount_bind_video0
qm> sudo dnf install ./rpmbuild/RPMS/noarch/*.rpm
qm> sudo podman restart qm
qm> sudo podman exec -it qm bash
qm> sudo ls -la /dev/video0
```