### PR TITLE
qm wm: add more mount bind for auto active login

### DIFF
--- a/qm-windowmanager/etc/containers/systemd/session-activate.container
+++ b/qm-windowmanager/etc/containers/systemd/session-activate.container
@@ -8,6 +8,7 @@ Environment=DBUS_SESSION_BUS_ADDRESS=unix:path=/run/dbus/system_bus_socket
 Image=quay.io/qm-images/wm_active_session:latest
 SecurityLabelType=qm_container_wayland_t
 Volume=/run/systemd:/run/systemd:ro
+Volume=/etc/dbus-1/system.d:/etc/dbus-1/system.d:ro
 Volume=/run/dbus/system_bus_socket:/run/dbus/system_bus_socket
 Volume=/run/user/0:/run/user/0
 


### PR DESCRIPTION
loginctl was not able to auto autoactive and it
was showing Permission Denied when executing
loginctl acticate <number session>. This
patch mount bind the required path to qm.