### PR TITLE
spec: remove ghost entry for qm.container

### DIFF
--- a/rpm/qm.spec
+++ b/rpm/qm.spec
@@ -366,7 +366,6 @@ fi
 %ghost %dir %{_datadir}/containers
 %ghost %dir %{_datadir}/containers/systemd
 %{_datadir}/containers/systemd/qm.container
-%ghost %{_sysconfdir}/containers/systemd/qm.container
 %{_mandir}/man8/*
 %ghost %dir %{_installscriptdir}
 %ghost %dir %{_installscriptdir}/rootfs


### PR DESCRIPTION
During service start in Fedora it try to read
qm.container from /etc/containers/systemd/qm.container instead of /usr/share/qm/qm.container and fails
as it's a ghost (empty) file.