### PR TITLE
Fedora-support

### DIFF
--- a/plans/e2e/ffi.fmf
+++ b/plans/e2e/ffi.fmf
@@ -1,6 +1,6 @@
 summary: FFI - QM FreedomFromInterference
 
-environment:
+environment+:
     CONTROL_CONTAINER_NAME: host
 
 discover:

--- a/plans/main.fmf
+++ b/plans/main.fmf
@@ -15,3 +15,7 @@ adjust:
    environment+:
        # Sample code to use manual packit repo
        PACKIT_COPR_PROJECT: packit/containers-qm-291
+
+ - when: distro == centos-stream-9, fedora
+   environment+:
+       CS_DISTRO: $@distro

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -228,6 +228,9 @@ tmt -c distro=centos-stream-9 run -a \
         plans -n /plans/e2e/tier-0
 ```
 
+Note:
+Fedora distro supported
+
 ##### Other tmt configurations
 
 In case of running against prepared image, such as AutoSD, use the following tmt command
@@ -257,4 +260,13 @@ Running FFI tests connecting c9s host, sets different tests environment from the
 ``` bash
 tmt -c scenario=ffi run -a prepare  provision --how connect \
     -u root -p ${PASSWORD} -P {PORT} -g localhost plan -n /plans/e2e/ffi
+```
+
+##### Running manual tests with PACKIT copr packages
+
+Assume debug of PR rpm needed to run locally,
+Use context `-c run=manual` with environment variable `-e PACKIT_COPR_PROJECT=<packir-qm-copr>`
+
+``` bash
+tmt -c distro=fedora-41 -c run=manual  run  -e PACKIT_COPR_PROJECT=packit/containers-qm-647 -a prepare -vvv -d  provision --how connect -u root -p <password> -P <port> -g localhost  plans -n /plans/e2e/tier-0 exec -d -vvv report --how junit
 ```

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -265,7 +265,7 @@ tmt -c scenario=ffi run -a prepare  provision --how connect \
 ##### Running manual tests with PACKIT copr packages
 
 Assume debug of PR rpm needed to run locally,
-Use context `-c run=manual` with environment variable `-e PACKIT_COPR_PROJECT=<packir-qm-copr>`
+Use context `-c run=manual` with environment variable `-e PACKIT_COPR_PROJECT=<packit-qm-copr>`
 
 ``` bash
 tmt -c distro=fedora-41 -c run=manual  run  -e PACKIT_COPR_PROJECT=packit/containers-qm-647 -a prepare -vvv -d  provision --how connect -u root -p <password> -P <port> -g localhost  plans -n /plans/e2e/tier-0 exec -d -vvv report --how junit

--- a/tests/e2e/set-ffi-env-e2e
+++ b/tests/e2e/set-ffi-env-e2e
@@ -48,6 +48,7 @@ export PART_ID=""
 export QC_SOC="${QC_SOC_TYPE:-SA8775P}"
 export SOC_DISTRO_FILE="${SOC_FILE:-/sys/devices/soc0/machine}"
 export QC_SOC_DISK="${QC_DISK_NAME:-sde}"
+export OS_DISTRO="${CS_DISTRO:-}"
 
 export BUILD_BLUECHI_FROM_GH_URL=""
 export QM_GH_URL=""
@@ -156,13 +157,18 @@ install_qm_rpms() {
   dnf config-manager --set-enabled crb
 
   local release_id
-  release_id=$(grep ^ID= /etc/os-release | cut -d = -f 2)
+  release_id=$(grep -oP '(?<=^ID=)\w+' /etc/os-release)
+  local version_id
+  version_id=$(grep -oP '(?<=^VERSION_ID=)\w+' /etc/os-release)
+  if [[ "$release_id" == "centos" ]]; then
+    release_id=epel
+  fi
 
   if [[ -n "${USE_QM_COPR}" ]]; then
       if [[ "${USE_QM_COPR}" != "release" ]]; then
-          dnf copr enable -y @centos-automotive-sig/bluechi-snapshot centos-stream-9
-          dnf copr enable -y "${USE_QM_COPR}" centos-stream-9
-      elif [[ "${USE_QM_COPR}" == "release" && "${release_id}" =~ "centos" ]]; then
+          dnf copr enable -y @centos-automotive-sig/bluechi-snapshot "$release_id-$version_id-$(arch)"
+          dnf copr enable -y "${USE_QM_COPR}" "$release_id-$version_id-$(arch)"
+      elif [[ "${USE_QM_COPR}" == "release" && "${release_id}" =~ (centos|fedora) ]]; then
           if [ ! -f /etc/yum.repos.d/autosd.repo ]; then
               info_message "Installing autosd repository"
               info_message "=============================="
@@ -263,14 +269,16 @@ info_message "Checking if QM already installed"
 info_message "=============================="
 if rpm -q qm &>/dev/null; then
 	QM_STATUS="$(systemctl is-enabled qm 2>&1)"
-        CS_DISTRO="$(grep -oP '(CentOS Stream [0-9]{1,2}).*' /etc/os-release)"
+        if test /etc/os-release; then
+             OS_DISTRO=$(grep -oP '(?<=^ID=)\w+' <<< "$(tr -d '"' < /etc/os-release)")
+        fi
 	if [ "$QM_STATUS" == "generated" ]; then
 		if [ "$(systemctl is-active qm)" == "active" ]; then
 			info_message "QM Enabled and Active"
 			info_message "=============================="
 			exit 0
    		fi
-		if test -d /var/qm -a -d /etc/qm -a -z "$CS_DISTRO" ; then
+		if test -d /var/qm -a -d /etc/qm -a -z "$OS_DISTRO" ; then
 			info_message "QM Enabled and not Active"
 			info_message "=============================="
 			exit 1


### PR DESCRIPTION
resolve #642 

Prepare Fedora image for testing
Changing the copr repositories to more genereric way
README explains how to tests copr PR rpm on local vm
For cases without /etc/os-release added distro context
to env-variable convert in main plan
