### PR TITLE
add NoRenesas tag to /tests/ffi/disk

### DIFF
--- a/tests/ffi/disk/main.fmf
+++ b/tests/ffi/disk/main.fmf
@@ -1,6 +1,6 @@
 summary: Test is calling systemd as stand alone test
 test: /bin/bash ./test.sh
 duration: 10m
-tag: ffi
+tag: [ffi, NoRenesas]
 framework: shell
 id: 54669ea4-755a-4506-aefc-a82f065e4d47


### PR DESCRIPTION
Add a NoRenesas tag to /tests/ffi/disk to disable it when there is no separated /var disk partition for QM.