### PR TITLE
Kvm test

### DIFF
--- a/.packit.sh
+++ b/.packit.sh
@@ -35,3 +35,5 @@ sed -i "s/^Source0:.*.tar.gz/Source0: %{name}-${HEAD_VERSION}.tar.gz/" ${SPEC_FI
 
 # Add update create additional subpackages in spec
 # Please refer `Let automation create/publish PR sub-packages` of docs/devel/README.md
+sed -i 's/\(enable_qm_mount_bind_kvm \).*/\11/' ${SPEC_FILE}
+

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -87,16 +87,32 @@ jobs:
     identifier: qm-tier-0
     tmt_plan: /plans/e2e/tier-0
     targets:
-      - fedora-latest
       - epel-9-x86_64
     tf_extra_params:
       environments:
         - artifacts:
           - *bluechi_copr_repo
+          hardware:
+            disk:
+             - size: ">= 20 GB"
+
+  - job: tests
+    trigger: pull_request
+    identifier: kvm-tier-0
+    tmt_plan: /plans/e2e/kvm-tier-0
+    targets:
+      - fedora-latest
+      - epel-9-x86_64
+    tf_extra_params:
+      environments:
+        - artifacts:
           - *bluechi_copr_repo_fedora
           hardware:
             disk:
              - size: ">= 20 GB"
+            virtualization:
+             is-supported: true
+
 
   - job: propose_downstream
     trigger: release

--- a/etc/containers/systemd/qm.container.d/qm_dropin_mount_bind_kvm.conf
+++ b/etc/containers/systemd/qm.container.d/qm_dropin_mount_bind_kvm.conf
@@ -1,7 +1,5 @@
 # Drop-in configuration for Podman to mount bind /dev/kvm from host to container
 #
-[containers]
-devices = [
-	"/dev/kvm:/dev/kvm",
-	"/dev/net/tun:/dev/net/tun"
-]
+[Container]
+AddDevice=-/dev/net/tun
+AddDevice=-/dev/kvm

--- a/plans/e2e/kvm-tier-0.fmf
+++ b/plans/e2e/kvm-tier-0.fmf
@@ -1,0 +1,19 @@
+summary: Kvm Tier 0 - QM sanity test
+
+discover:
+    how: fmf
+    filter: 'tier:0&tag:kvm'
+
+prepare+:
+    #Enable copr and install rpms
+    - name: Expose /dev kvm to QM
+      script: |
+          cd tests/e2e
+          bash ./lib/repoutils
+
+execute:
+    how: tmt
+
+report:
+    how: junit
+

--- a/plans/e2e/tier-0.fmf
+++ b/plans/e2e/tier-0.fmf
@@ -2,7 +2,7 @@ summary: Tier 0 - QM sanity test
 
 discover:
     how: fmf
-    filter: tier:0
+    filter: 'tier:0&tag:-setup'
 
 prepare+:
   - name: Set QM environment

--- a/plans/main.fmf
+++ b/plans/main.fmf
@@ -9,6 +9,14 @@ prepare:
     order: 20
     package:
       - podman
+  - name: Remove unsupported /dev configs
+    how: shell
+    order: 60
+    script: |
+        if ! test -e /dev/kvm; then
+          dnf remove -y qm_mount_bind_kvm
+        fi
+
 
 adjust:
  - when: run == manual

--- a/rpm/qm.spec
+++ b/rpm/qm.spec
@@ -160,6 +160,7 @@ sed -i 's/^install: man all/install:/' Makefile
 install -d %{buildroot}%{_sysconfdir}/containers/containers.conf.d
 install -d %{buildroot}%{rootfs_qm}%{_sysconfdir}/containers/systemd
 install -d %{buildroot}%{_sysconfdir}/qm/containers/containers.conf.d
+install -d %{buildroot}%{_sysconfdir}/containers/systemd/qm.container.d
 
 ####################################################################
 ################# QM Window Manager ################################
@@ -223,13 +224,9 @@ install -d %{buildroot}%{_sysconfdir}/qm/containers/containers.conf.d
 # START - qm dropin sub-package - mount kvm            #
 ########################################################
 %if %{enable_qm_mount_bind_kvm}
-    # first step - add drop-in file in /etc/containers/containers.d.conf/qm_dropin_mount_bind_kvm.conf
-    # to QM container mount bind /dev/kvm
-    install -m 644 %{_builddir}/qm-%{version}/etc/qm/containers/containers.conf.d/qm_dropin_mount_bind_kvm.conf %{buildroot}%{_sysconfdir}/containers/containers.conf.d/qm_dropin_mount_bind_kvm.conf
-
-    # second step - add drop-in file in /etc/qm/containers/containers.d.conf/qm_dropin/mount_bind_kvm.conf
+    # Add config for qm only - add drop-in file in /etc/containers/systemd/qm.container.d/qm_dropin_mount_bind_kvm.conf
     # to nested containers in QM env mount bind it in /dev/kvm
-    install -m 644 %{_builddir}/qm-%{version}/etc/qm/containers/containers.conf.d/qm_dropin_mount_bind_kvm.conf %{buildroot}%{_sysconfdir}/qm/containers/containers.conf.d/qm_dropin_mount_bind_kvm.conf
+    install -m 644 %{_builddir}/qm-%{version}/etc/containers/systemd/qm.container.d/qm_dropin_mount_bind_kvm.conf %{buildroot}%{_sysconfdir}/containers/systemd/qm.container.d/qm_dropin_mount_bind_kvm.conf
 %endif
 ########################################################
 # END - qm dropin sub-package - mount kvm              #
@@ -494,12 +491,11 @@ BuildArch: noarch
 
 %description -n qm_mount_bind_kvm
 This sub-package installs a drop-in configurations for the QM.
-It creates the `/etc/qm/containers/containers.conf.d/` directory for adding
-additional drop-in configurations.
+It creates the `/etc/containers/systemd/qm.container.d/` directory for adding
+additional quadlet drop-in configurations.
 
 %files -n qm_mount_bind_kvm
-%{_sysconfdir}/containers/containers.conf.d/qm_dropin_mount_bind_kvm.conf
-%{_sysconfdir}/qm/containers/containers.conf.d/qm_dropin_mount_bind_kvm.conf
+%{_sysconfdir}/containers/systemd/qm.container.d/qm_dropin_mount_bind_kvm.conf
 %endif
 
 #######################################

--- a/setup
+++ b/setup
@@ -290,6 +290,12 @@ case "$1" in
     if [ "$SYSTEMCTL_SKIP" == "N" ]; then
 	    systemctl daemon-reload
 	    systemctl start qm.service
+            if [ "$(systemctl is-active qm.service)" != "active" ]; then
+               journal=$(journalctl --no-pager -xu qm.service)
+               echo QM service is not up details:
+               echo "$journal"
+               exit 1
+            fi
     else
       /usr/libexec/podman/quadlet /run/systemd/generator/
     fi

--- a/tests/e2e/lib/repoutils
+++ b/tests/e2e/lib/repoutils
@@ -1,0 +1,78 @@
+#!/bin/bash
+#
+# Copyright 2023 The qm Authors
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; If not, see <http://www.gnu.org/licenses/>.
+
+install_autosd_repo() {
+  ###########################################################################
+  # Description:                                                            #
+  # Install autosd repository                                               #
+  #                                                                         #
+  # Arguments:                                                              #
+  #          None                                                           #
+  ###########################################################################
+
+    touch /etc/yum.repos.d/autosd.repo
+    cat > "/etc/yum.repos.d/autosd.repo" << EOF
+[autosd]
+name=Automotive-Sig \$releasever
+baseurl=https://autosd.sig.centos.org/AutoSD-9/nightly/repos/AutoSD/compose/AutoSD/\$basearch/os
+enabled=1
+gpgcheck=0
+EOF
+}
+
+
+install_qm_rpms() {
+  ###########################################################################
+  # Description:                                                            #
+  # Enable and install necessary qm rpms and eendencies                     #
+  #                                                                         #
+  # Arguments: Should be exported by calling script                         #
+  #   USE_QM_COPR:  copr repo to install                                    #
+  ###########################################################################
+
+  if [[ -n "${USE_QM_COPR}" ]]; then
+     USE_QM_COPR="${PACKIT_COPR_PROJECT:-rhcontainerbot/qm}"
+  fi
+  info_message "Installing qm setup rpm"
+  info_message "Installing qm using ${USE_QM_COPR} repo"
+  info_message "=============================="
+  dnf install -y 'dnf-command(config-manager)'
+  dnf config-manager --set-enabled crb
+
+  local release_id
+  release_id=$(grep -oP '(?<=^ID=)\w+' <<< "$(tr -d '"' < /etc/os-release)")
+  local version_id
+  version_id=$(grep -oP '(?<=^VERSION_ID=)\w+' <<< "$(tr -d '"' < /etc/os-release)")
+  if [[ "$release_id" == "centos" ]]; then
+    release_id=epel
+  fi
+
+  if [[ -n "${USE_QM_COPR}" ]]; then
+      if [[ "${USE_QM_COPR}" != "release" ]]; then
+          dnf copr enable -y @centos-automotive-sig/bluechi-snapshot "$release_id-$version_id-$(arch)"
+          dnf copr enable -y "${USE_QM_COPR}" "$release_id-$version_id-$(arch)"
+      elif [[ "${USE_QM_COPR}" == "release" && "${release_id}" =~ (centos|epel|fedora) ]]; then
+          if [ ! -f /etc/yum.repos.d/autosd.repo ]; then
+              info_message "Installing autosd repository"
+              info_message "=============================="
+              install_autosd_repo
+          fi
+      fi
+  fi
+
+  dnf install -y bluechi-ctl bluechi-agent bluechi-controller qm hostname
+}

--- a/tests/e2e/set-ffi-env-e2e
+++ b/tests/e2e/set-ffi-env-e2e
@@ -33,6 +33,8 @@ source "${SCRIPT_DIR}"/lib/systemd
 source "${SCRIPT_DIR}"/lib/tests
 # shellcheck disable=SC1091
 source "${SCRIPT_DIR}"/lib/diskutils
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}"/lib/repoutils
 
 # GLOBALS
 export CONFIG_NODE_AGENT_PATH="/etc/bluechi/agent.conf.d/agent.conf"
@@ -148,38 +150,6 @@ while [ $# -gt 0 ]; do
     esac
 done
 
-install_qm_rpms() {
-
-  info_message "Installing qm setup rpm"
-  info_message "Installing qm using ${USE_QM_COPR} repo"
-  info_message "=============================="
-  dnf install -y 'dnf-command(config-manager)'
-  dnf config-manager --set-enabled crb
-
-  local release_id
-  release_id=$(grep -oP '(?<=^ID=)\w+' <<< "$(tr -d '"' < /etc/os-release)")
-  local version_id
-  version_id=$(grep -oP '(?<=^VERSION_ID=)\w+' <<< "$(tr -d '"' < /etc/os-release)")
-  if [[ "$release_id" == "centos" ]]; then
-    release_id=epel
-  fi
-
-  if [[ -n "${USE_QM_COPR}" ]]; then
-      if [[ "${USE_QM_COPR}" != "release" ]]; then
-          dnf copr enable -y @centos-automotive-sig/bluechi-snapshot "$release_id-$version_id-$(arch)"
-          dnf copr enable -y "${USE_QM_COPR}" "$release_id-$version_id-$(arch)"
-      elif [[ "${USE_QM_COPR}" == "release" && "${release_id}" =~ (centos|fedora) ]]; then
-          if [ ! -f /etc/yum.repos.d/autosd.repo ]; then
-              info_message "Installing autosd repository"
-              info_message "=============================="
-              install_autosd_repo
-          fi
-      fi
-  fi
-
-  dnf install -y bluechi-ctl bluechi-agent bluechi-controller qm hostname
-}
-
 setup_qm_services() {
 
   info_message "Setup qm services"
@@ -228,18 +198,6 @@ fi
   systemctl start bluechi-agent
   # Restart qm to read lates bluechi-agent.conf
   systemctl restart qm
-}
-
-install_autosd_repo() {
-    # Install autosd repository
-    touch /etc/yum.repos.d/autosd.repo
-    cat > "/etc/yum.repos.d/autosd.repo" << EOF
-[autosd]
-name=Automotive-Sig \$releasever
-baseurl=https://autosd.sig.centos.org/AutoSD-9/nightly/repos/AutoSD/compose/AutoSD/\$basearch/os
-enabled=1
-gpgcheck=0
-EOF
 }
 
 info_message "Starting setup"

--- a/tests/qm-sanity-test/check_qm_is_up.fmf
+++ b/tests/qm-sanity-test/check_qm_is_up.fmf
@@ -2,5 +2,6 @@ summary: Test qm is up and running
 test: /bin/bash ./check_qm_is_up.sh
 duration: 10m
 tier: 0
+tag: kvm
 framework: shell
 id: b82a5766-275b-4635-9c2a-7ab3d8c6dc05

--- a/tests/qm-sanity-test/check_qm_podman_is_ok.fmf
+++ b/tests/qm-sanity-test/check_qm_podman_is_ok.fmf
@@ -2,5 +2,6 @@ summary: Test podman in qm is ok
 test: /bin/bash ./check_qm_podman_is_ok.sh
 duration: 10m
 tier: 0
+tag: kvm
 framework: shell
 id: ac4aac07-094b-4d22-b5f6-b85bc39da119

--- a/tests/qm-sanity-test/check_qm_podman_quadlet_is_ok.fmf
+++ b/tests/qm-sanity-test/check_qm_podman_quadlet_is_ok.fmf
@@ -2,5 +2,6 @@ summary: Test podman run and exec container in qm with service file
 test: /bin/bash ./check_qm_podman_quadlet_is_ok.sh
 duration: 10m
 tier: 0
+tag: kvm
 framework: shell
 id: b2071703-f9d4-4945-aa2d-0cf3abeaecb7

--- a/tests/qm-sanity-test/check_qm_podman_quadlet_is_ok.sh
+++ b/tests/qm-sanity-test/check_qm_podman_quadlet_is_ok.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -euvx
+#!/bin/bash -x
 
 # shellcheck disable=SC1091
 source ../e2e/lib/utils
@@ -13,20 +13,18 @@ Description=the qm-sanity-test sleep container
 After=local-fs.target
 
 [Container]
-Image=registry.access.redhat.com/ubi9-minimal:latest
+Image=quay.io/fedora/fedora
 Exec=sleep 1000
 
 [Install]
 # Start by default on boot
 WantedBy=multi-user.target default.target
 EOF
-
     info_message "check_qm_podman_quadlet_is_ok(): qm-sanity-test container reload & restart"
     exec_cmd_with_pass_info "podman exec qm systemctl daemon-reload"
     exec_cmd_with_pass_info "podman exec qm systemctl start qm-sanity-test"
     exec_cmd_with_pass_info "podman exec qm systemctl status qm-sanity-test | grep -i started"
-    exec_cmd_with_pass_info "podman exec qm podman run alpine echo Hello QM"
-
+    exec_cmd_with_pass_info "podman exec qm podman run fedora echo Hello QM"
     info_message "PASS: check_qm_podman_quadlet_is_ok()"
     exit 0
 }

--- a/tests/qm-sanity-test/check_qm_setup_succeeds.fmf
+++ b/tests/qm-sanity-test/check_qm_setup_succeeds.fmf
@@ -2,5 +2,8 @@ summary: Test qm setup script succeeds
 test: /usr/share/qm/setup
 duration: 10m
 tier: 0
+#Need to run first for Fedora use case
+tag: [kvm,setup]
+order: 40
 framework: shell
 id: 310b2af2-6661-4b00-a563-67cc021e732b


### PR DESCRIPTION
Adding KVM tier-0 rpm subpackage testing

KVM tier-0 tests dedicated for kvm tests. 
It checks /dev/kvm. nested virtualization exist.
In case not, it removes qm_mount_bind_kvm rpm, in case installed by packit.

Test check_qm_setup_succeeds is the irst test to run,
The test check repo setup script is working properly

Packit support for nested kvm support added currently for fedora/c9s
Kvm tests should be introduced later.
Introducing QM quadlets drop-ins for extending qm.container base quadlet.
Using as single point of configuration.
Replacing the usage of containers.conf

Fedora is failing due to #666
