### PR TITLE
tests/ffi: add test checking /sys is read-only

### DIFF
--- a/tests/ffi/sys_read_only/PURPOSE
+++ b/tests/ffi/sys_read_only/PURPOSE
@@ -1,0 +1,12 @@
+Title:
+    Verifies that /sys is read-only in QM partition.
+
+Description:
+    This test executes `test -r /sys && test ! -w /sys` in QM partition, no other input.
+        podman exec qm "test -r /sys && test ! -w /sys"
+
+Expected result:
+    out: [ INFO  ] PASS: check_sys_read_only: As expected, /sys is read-only in QM partition.
+
+Jira:
+    VROOM-24445

--- a/tests/ffi/sys_read_only/README.md
+++ b/tests/ffi/sys_read_only/README.md
@@ -1,0 +1,7 @@
+# FFI - sys_read_only
+
+This test is intended to confirm that /sys is read-only in QM partition.
+
+## This Test Set includes these tests
+
+1. Confirm that /sys is read-only in QM partition.

--- a/tests/ffi/sys_read_only/main.fmf
+++ b/tests/ffi/sys_read_only/main.fmf
@@ -1,0 +1,19 @@
+summary: Test that /sys is read-only in QM partition.
+description: |
+    This tests confirms that /sys folder is present and read-only in the QM
+    partition. The test executes `test -r /sys && test ! -w /sys` in QM
+    partition, no other input.
+
+    Test inputs:
+        None
+
+    Expected results:
+        out: [ INFO  ] PASS: check_sys_read_only: As expected, /sys is read-only in QM partition.
+
+    Results location:
+        output.txt
+contact: Albert Esteve <aesteve@redhat.com>
+test: /bin/bash ./test.sh
+duration: 10m
+tag: ffi
+framework: shell

--- a/tests/ffi/sys_read_only/main.fmf
+++ b/tests/ffi/sys_read_only/main.fmf
@@ -17,3 +17,4 @@ test: /bin/bash ./test.sh
 duration: 10m
 tag: ffi
 framework: shell
+id: 3fc9b0f9-5098-4bd4-a086-e75dc56ea569

--- a/tests/ffi/sys_read_only/test.sh
+++ b/tests/ffi/sys_read_only/test.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -euvx
+
+# shellcheck disable=SC1091
+. ../../e2e/lib/utils
+
+check_sys_read_only(){
+    # Check /sys is read-only in QM partition
+    if podman exec qm /bin/sh -c 'test -r /sys && test ! -w /sys'; then
+        info_message "PASS: check_sys_read_only: As expected, /sys is read-only in QM partition."
+        exit 0
+    else
+        info_message "Found a non-read-only /sys folder in QM partition: $(podman exec -t qm ls -ld /sys)"
+        info_message "FAIL: check_sys_read_only: Check for /sys in QM partition failed, it should be read-only."
+        exit 1
+    fi
+}
+
+check_sys_read_only


### PR DESCRIPTION
Test to ensure that /sys is read-only inside the
QM container.