### PR TITLE
Add fedora fix

### DIFF
--- a/containers.conf
+++ b/containers.conf
@@ -1,4 +1,5 @@
 [containers]
+default_ulimits = []
 default_sysctls = []
 
 cgroup_conf=[

--- a/plans/e2e/kvm-tier-0.fmf
+++ b/plans/e2e/kvm-tier-0.fmf
@@ -5,8 +5,7 @@ discover:
     filter: 'tier:0&tag:kvm'
 
 prepare+:
-    #Enable copr and install rpms
-    - name: Expose /dev kvm to QM
+    - name: Enable copr and install rpms
       script: |
           cd tests/e2e
           bash ./lib/repoutils

--- a/plans/main.fmf
+++ b/plans/main.fmf
@@ -9,14 +9,7 @@ prepare:
     order: 20
     package:
       - podman
-  - name: Remove unsupported /dev configs
-    how: shell
-    order: 60
-    script: |
-        if ! test -e /dev/kvm; then
-          dnf remove -y qm_mount_bind_kvm
-        fi
-
+      - bc
 
 adjust:
  - when: run == manual

--- a/setup
+++ b/setup
@@ -261,6 +261,15 @@ echo  "  * agent hostname: ${AGENT_HOSTNAME}"
 echo
 
 if [ "${REMOVE_QM_ROOTFS}" == "Y" ]; then
+    # Unmount qm binds
+    qm_mounts="$(mount | grep /qm  | cut -d" " -f3)"
+    if [ -z "$qm_mounts" ]; then
+        echo "No mount points found under /qm."
+    else
+        for mount in $qm_mounts; do
+            umount "$mount"
+        done
+    fi
     # Get the one path below, i.e: /usr/lib/qm instead /usr/lib/qm/rootfs
     path_qm_rootfs=$(${QM_ROOTFS_TOOL} | sed 's|/[^/]*$||')
     rm -rf "${path_qm_rootfs}"

--- a/tests/e2e/lib/repoutils
+++ b/tests/e2e/lib/repoutils
@@ -76,3 +76,30 @@ install_qm_rpms() {
 
   dnf install -y bluechi-ctl bluechi-agent bluechi-controller qm hostname
 }
+
+set_qm_rlimits() {
+  ###########################################################################
+  # Description:                                                            #
+  # This function sets the QM containers.conf file to set specific resource #
+  # limits (rlimits) for QM containers, such as:                            #
+  #     nofile (maximum open files).                                        #
+  #     nproc (maximum processes)                                           #
+  #                                                                         #
+  #     Reference: https://github.com/containers/podman/issues/24692        #
+  #                                                                         #
+  # Arguments: None                                                         #
+  ###########################################################################
+    local ulimit_nofile
+    local ulimit_nproc
+    info_message "set_qm_rlimits(): prepare qm containers.conf file, update ulimits"
+    # Check if QM containers.conf exists
+    exec_cmd "test -e ${QM_CTR_CFG}"
+    # Calculate ulimits
+    ulimit_nofile=$(( $(ulimit -n) * U_NOFILE_PRCTG / 100 ))
+    ulimit_nproc=$(( $(ulimit -u) * U_NPROC_PRCTG / 100 ))
+    # Update containers.conf
+    exec_cmd "sed -i -E 's/(default_ulimits = \[)/\1\"nproc=$ulimit_nproc:$ulimit_nproc\",\"nofile=$ulimit_nofile:$ulimit_nofile\"/' $QM_CTR_CFG"
+    # Verify limits are set
+    info_message "fix_qm_rlimits(): verify limits are set"
+    exec_cmd "grep -o '\(nproc.*\",\|nofile.*\"\)' ${QM_CTR_CFG} | tr -d '\",' "
+}

--- a/tests/e2e/lib/utils
+++ b/tests/e2e/lib/utils
@@ -53,6 +53,7 @@ exec_cmd() {
     local cmd="$1"
     eval "$cmd"
     if_error_exit "Error: Command $cmd failed"
+    info_message "PASS: Command $cmd successful"
 }
 
 cleanup_node_services() {

--- a/tests/e2e/set-ffi-env-e2e
+++ b/tests/e2e/set-ffi-env-e2e
@@ -51,6 +51,10 @@ export QC_SOC="${QC_SOC_TYPE:-SA8775P}"
 export SOC_DISTRO_FILE="${SOC_FILE:-/sys/devices/soc0/machine}"
 export QC_SOC_DISK="${QC_DISK_NAME:-sde}"
 export OS_DISTRO="${CS_DISTRO:-}"
+export QM_CTR_CFG="${QM_CNTR_CONFIG:-/etc/qm/containers/containers.conf}"
+export U_NOFILE_PRCTG=${NOFILE_RATIO:-50}
+export U_NPROC_PRCTG=${NPROC_RATIO:-75}
+
 
 export BUILD_BLUECHI_FROM_GH_URL=""
 export QM_GH_URL=""
@@ -163,6 +167,8 @@ setup_qm_services() {
   # Curl files into here,
   # Fix: default setup:main should be removed on next qm release
   /usr/share/qm/setup --hostname localrootfs
+  # Update QM relimits
+  set_qm_rlimits
   cat > /etc/bluechi/controller.conf << 'EOF'
 [bluechi-controller]
 AllowedNodeNames=qm.localrootfs,localrootfs

--- a/tests/qm-sanity-test/check_qm_podman_quadlet_is_ok.sh
+++ b/tests/qm-sanity-test/check_qm_podman_quadlet_is_ok.sh
@@ -21,18 +21,12 @@ Exec=sleep 1000
 WantedBy=multi-user.target default.target
 EOF
     info_message "check_qm_podman_quadlet_is_ok(): qm-sanity-test container reload & restart"
-    exec_cmd_with_pass_info "podman exec qm systemctl daemon-reload"
-    exec_cmd_with_pass_info "podman exec qm systemctl start qm-sanity-test"
-    exec_cmd_with_pass_info "podman exec qm systemctl status qm-sanity-test | grep -i started"
-    exec_cmd_with_pass_info "podman exec qm podman run fedora echo Hello QM"
+    exec_cmd "podman exec qm systemctl daemon-reload"
+    exec_cmd "podman exec qm systemctl start qm-sanity-test"
+    exec_cmd "podman exec qm systemctl status qm-sanity-test | grep -i started"
+    exec_cmd "podman exec qm podman run fedora echo Hello QM"
     info_message "PASS: check_qm_podman_quadlet_is_ok()"
     exit 0
-}
-
-exec_cmd_with_pass_info(){
-    local command="$1"
-    exec_cmd "${command}"
-    info_message "PASS: Command ${command} successful"
 }
 
 check_qm_podman_quadlet_is_ok

--- a/tests/qm-sanity-test/check_qm_podman_ulimits_are_set.fmf
+++ b/tests/qm-sanity-test/check_qm_podman_ulimits_are_set.fmf
@@ -1,0 +1,8 @@
+summary: Test podman ulimits qm are set
+test: /bin/bash ./check_qm_podman_ulimits_are_set.sh
+duration: 10m
+tier: 0
+tag: [kvm,setup]
+#Need to run first for Fedora use case
+order: 40
+framework: shell

--- a/tests/qm-sanity-test/check_qm_podman_ulimits_are_set.sh
+++ b/tests/qm-sanity-test/check_qm_podman_ulimits_are_set.sh
@@ -1,0 +1,27 @@
+#!/bin/bash -x
+
+# shellcheck disable=SC1091
+source ../e2e/lib/utils
+
+U_NOFILE_PRCTG=${NOFILE_RATIO:-0.5}
+U_NPROC_PRCTG=${NPROC_RATIO:-0.75}
+QM_CTR_CFG=/etc/qm/containers/containers.conf
+
+# Verify podman run and exec container inside qm with service file
+check_qm_podman_ulimits_are_set(){
+    local ulimit_nofile
+    local ulimit_nproc=
+    info_message "check_qm_podman_ulimits_are_set(): \
+    prepare qm containers.conf file
+    refer issue #666"
+    info_message "check_qm_podman_ulimits_are_set(): qm-sanity-test update qm ulimits"
+    exec_cmd "test -e ${QM_CTR_CFG}"
+    ulimit_nofile=$(printf %.0f "$(echo "$(ulimit -n) * $U_NOFILE_PRCTG" | bc)")
+    ulimit_nproc=$(printf %.0f "$(echo "$(ulimit -u) * $U_NPROC_PRCTG" | bc)")
+    exec_cmd "sed -i -E 's/(default_ulimits = \[)/\1\"nproc=$ulimit_nproc:$ulimit_nproc\",\"nofile=$ulimit_nofile:$ulimit_nofile\"/' $QM_CTR_CFG"
+    info_message "check_qm_podman_ulimits_are_set(): qm-sanity-test verify limits are set"
+    exec_cmd "grep -oP \(nproc.*\",\|nofile.*\"\)  ${QM_CTR_CFG} | tr -d '\t\",' "
+    exit 0
+}
+
+check_qm_podman_ulimits_are_set

--- a/tests/qm-sanity-test/check_qm_setup_succeeds.fmf
+++ b/tests/qm-sanity-test/check_qm_setup_succeeds.fmf
@@ -4,6 +4,6 @@ duration: 10m
 tier: 0
 #Need to run first for Fedora use case
 tag: [kvm,setup]
-order: 40
+order: 30
 framework: shell
 id: 310b2af2-6661-4b00-a563-67cc021e732b


### PR DESCRIPTION
This commit fix #666, till full support in podman

Fedora tests run only on kvm-tier-0,
test setup script, first, then apply rlimit test fix
    
c9s fix, inside prepare script set-ffi-env-e2e

Update util exec_cmd to print successful commands, 
   
