### PR TITLE
check /var partition before run /tests/ffi/disk

### DIFF
--- a/tests/ffi/disk/test.sh
+++ b/tests/ffi/disk/test.sh
@@ -4,6 +4,25 @@
 
 . ../common/prepare.sh
 
+check_var_partition(){
+   if stat /run/ostree-booted > /dev/null 2>&1; then
+      qm_var_partition="part /var"
+   else
+      qm_var_partition="part /usr/lib/qm/rootfs/var"
+   fi
+
+   if [[ "$(lsblk -o 'MAJ:MIN,TYPE,MOUNTPOINTS')" =~ ${qm_var_partition} ]]; then
+      info_message "A separate /var partition was detected on the image."
+   else
+      lsblk
+      df -kh
+      info_message "FAIL: No separate /var partition was detected on the image."
+      info_message "Test terminated, it requires a separate /var disk partition for QM to run this test."
+      exit 1
+   fi
+}
+
+check_var_partition
 disk_cleanup
 prepare_test
 
@@ -30,12 +49,14 @@ exec_cmd "podman exec -it qm /bin/bash -c \
          'podman exec -it ffi-qm ./QM/file-allocate'"
 
 if ! eval "fallocate -l 2G /root/file.lock" ; then
-   echo "No space left on device"
+   info_message "FAIL: No space left on device."
+   podman exec -it qm /bin/bash -c 'podman  rmi -i -f --all; echo $?'
    exit 1
 fi
 
 ls -lh /root/file.lock
+info_message "PASS: The disk in qm is full, host is not affected."
 
-# Calling cleanup QM directorly to workaround exit code once
+# Calling cleanup QM directory to workaround exit code once
 # /var/qm disk is full.
 podman exec -it qm /bin/bash -c 'podman  rmi -i -f --all; echo $?'


### PR DESCRIPTION
Added a function `check_var_partition` to check if a separate /var disk partition exists before executing the test, so as not to block the execution of other test cases after it.
