### PR TITLE
fix requirement of modprobe ip_tables

### DIFF
--- a/rpm/qm.spec
+++ b/rpm/qm.spec
@@ -62,6 +62,7 @@ BuildRequires: pkgconfig(systemd)
 BuildRequires: selinux-policy >= %_selinux_policy_version
 BuildRequires: selinux-policy-devel >= %_selinux_policy_version
 
+Requires: iptables
 Requires: parted
 Requires: containers-common
 Requires: selinux-policy >= %_selinux_policy_version
@@ -109,7 +110,7 @@ install -d %{buildroot}%{_sysconfdir}/containers/containers.conf.d
 # Execute the script to create seccomp rules after the package is installed
 /usr/share/qm/create-seccomp-rules
 /usr/share/qm/comment-tz-local # FIX-ME GH-issue: 367
-/usr/share/qm/qm-is-ostree
+modprobe ip_tables # podmand netavark requires at host to load
 
 %preun
 if [ $1 = 0 ]; then

--- a/setup
+++ b/setup
@@ -151,6 +151,11 @@ install() {
         EXTRA_FLAG="--use-host-config"
     fi
 
+    # SecurityLabelNested not supported so far in CentOS Stream 9 or lower
+    if grep -qi "^ID=centos" /etc/os-release && [[ $(grep -oP '^VERSION_ID="\K[0-9]+' /etc/os-release) -le 9 ]]; then
+        sed -i '/SecurityLabelNested/d' /usr/share/containers/systemd/qm.container
+    fi
+
     cmd_dnf_install="dnf -y install --releasever=${VERSION_ID} --installroot ${ROOTFS} ${PACKAGES_TO_INSTALL} ${EXTRA_FLAG}"
     echo "$cmd_dnf_install"
     ${cmd_dnf_install}


### PR DESCRIPTION
- netavark requires ip_tables, otherwise podman complains
- removed in %post isostres command (not required at all)