### PR TITLE
Add test to run basic qm image build with a-i-b

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -113,6 +113,18 @@ jobs:
             virtualization:
              is-supported: true
 
+  - job: tests
+    trigger: pull_request
+    identifier: automotive-image-builder
+    tmt_plan: /plans/e2e/aib
+    targets:
+      - epel-9-x86_64
+    tf_extra_params:
+      environments:
+          hardware:
+            disk:
+             - size: ">= 20 GB"
+
 
   - job: propose_downstream
     trigger: release

--- a/plans/e2e/aib.fmf
+++ b/plans/e2e/aib.fmf
@@ -1,0 +1,11 @@
+summary: automotive-image-builder QM build test
+
+discover:
+    how: fmf
+    filter: 'tag:aib'
+
+execute:
+    how: tmt
+
+report:
+    how: junit

--- a/tests/aib/check_qm_with_aib.fmf
+++ b/tests/aib/check_qm_with_aib.fmf
@@ -1,0 +1,6 @@
+summary: Test basic QM image build with automotive-image-builder
+test: /bin/bash ./check_qm_with_aib.sh
+duration: 20m
+tag: aib
+framework: shell
+id: 146b987f-698f-4f84-8029-eaa253d049ce

--- a/tests/aib/check_qm_with_aib.sh
+++ b/tests/aib/check_qm_with_aib.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Download basic QM manifest
+curl -o qm.aib.yml "https://gitlab.com/CentOS/automotive/src/automotive-image-builder/-/raw/main/examples/qm.aib.yml?ref_type=heads"
+
+USE_QM_COPR="${PACKIT_COPR_PROJECT:-rhcontainerbot/qm}"
+COPR_URL="https://download.copr.fedorainfracloud.org/results/${USE_QM_COPR}/epel-9-$(uname -m)/"
+#shellcheck disable=SC2089
+EXTRA_REPOS='extra_repos=[{"id":"qm_build","baseurl":"'"$COPR_URL"'"}]'
+
+# Run AIB in container
+curl -o auto-image-builder.sh "https://gitlab.com/CentOS/automotive/sample-images/-/raw/main/auto-image-builder.sh?ref_type=heads"
+#shellcheck disable=SC2027,SC2090,SC2086
+/bin/bash auto-image-builder.sh build --export qcow2 --define "'"$EXTRA_REPOS"'" qm.aib.yml qm.qcow2


### PR DESCRIPTION
Introducing a new sanity test, that builds a basic qm image with automotive-image-builder.

Resolves:  #675 