### PR TITLE
Adding test metadata for validators

### DIFF
--- a/tests/ffi/attempts_to_access_forbidden_file_system_resource/devices/check_dev_console.fmf
+++ b/tests/ffi/attempts_to_access_forbidden_file_system_resource/devices/check_dev_console.fmf
@@ -1,4 +1,16 @@
 summary: Test that the device /dev/console is not available in the QM partition.
+description: |
+    This tests confirms that the device /dev/console is not available in the QM partition.
+    The test executes `test -c /dev/console` in QM partition, no other input.
+
+    Test inputs:
+        None
+
+    Expected results:
+        [ INFO  ] PASS: check_dev_console_not_available: As expected, /dev/console is not available in the QM partition.
+
+    Results location:
+        output.txt
 test: /bin/bash ./check_dev_console.sh
 duration: 10m
 tag: ffi

--- a/tests/ffi/attempts_to_access_forbidden_file_system_resource/devices/check_dev_disk.fmf
+++ b/tests/ffi/attempts_to_access_forbidden_file_system_resource/devices/check_dev_disk.fmf
@@ -1,4 +1,15 @@
 summary: Test that the device /dev/disk is not available in the QM partition.
+description: |
+    This tests confirms that the device /dev/disk is not available in the QM partition.
+     The test executes `test -d /dev/disk` in QM partition, no other input.
+
+    Test inputs:
+        None
+
+    Expected results:
+        [ INFO  ] PASS: check_dev_disk_not_available: As expected, /dev/disk is not available in the QM partition.
+    Results location:
+        output.txt
 test: /bin/bash ./check_dev_disk.sh
 duration: 10m
 tag: ffi

--- a/tests/ffi/attempts_to_access_forbidden_file_system_resource/devices/check_dev_kmsg.fmf
+++ b/tests/ffi/attempts_to_access_forbidden_file_system_resource/devices/check_dev_kmsg.fmf
@@ -1,4 +1,16 @@
 summary: Test that the device /dev/kmsg is not available in the QM partition.
+description: |
+    This tests confirms that the device /dev/kmsg is not available in the QM partition.
+    The test executes `test -c /dev/kmsg` in QM partition, no other input.
+
+    Test inputs:
+        None
+
+    Expected results:
+        [ INFO  ] PASS: check_dev_kmsg_not_available: As expected, /dev/kmsg is not available in the QM partition.
+
+    Results location:
+        output.txt
 test: /bin/bash ./check_dev_kmsg.sh
 duration: 10m
 tag: ffi

--- a/tests/ffi/attempts_to_access_forbidden_file_system_resource/regular_os_files/check_etc_qm.fmf
+++ b/tests/ffi/attempts_to_access_forbidden_file_system_resource/regular_os_files/check_etc_qm.fmf
@@ -1,4 +1,16 @@
 summary: Test that the directory /etc/qm cannot be accessed in the QM partition.
+description: |
+    This tests confirms that the directory /etc/qm cannot be accessed in the QM partition.
+    The test executes `test -d /etc/qm` in QM partition, no other input.
+
+    Test inputs:
+        None
+
+    Expected results:
+        out: [ INFO  ] PASS: check_etc_qm_not_accessible: As expected, /etc/qm is not accessible in the QM partition
+
+    Results location:
+        output.txt
 test: /bin/bash ./check_etc_qm.sh
 duration: 10m
 tag: ffi

--- a/tests/ffi/attempts_to_access_forbidden_file_system_resource/regular_os_files/check_usr_lib_qm.fmf
+++ b/tests/ffi/attempts_to_access_forbidden_file_system_resource/regular_os_files/check_usr_lib_qm.fmf
@@ -1,4 +1,16 @@
 summary: Test that the directory /usr/lib/qm cannot be accessed in the QM partition.
+description: |
+    This tests confirms that the directory /usr/lib/qm cannot be accessed in the QM partition
+    The test executes `test -d /usr/lib/qm` in QM partition, no other input.
+
+    Test inputs:
+        None
+
+    Expected results:
+        out: [ INFO  ] PASS: check_usr_lib_qm_not_accessible: As expected, /usr/lib/qm is not accessible in the QM partition.
+
+    Results location:
+        output.txt
 test: /bin/bash ./check_usr_lib_qm.sh
 duration: 10m
 tag: ffi

--- a/tests/ffi/attempts_to_access_forbidden_file_system_resource/regular_os_files/check_usr_share_qm.fmf
+++ b/tests/ffi/attempts_to_access_forbidden_file_system_resource/regular_os_files/check_usr_share_qm.fmf
@@ -1,4 +1,16 @@
 summary: Test that the directory /usr/share/qm cannot be accessed in the QM partition.
+description: |
+    This tests confirms that the directory /usr/share/qm cannot be accessed in the QM partition.
+    The test executes `test -d /usr/share/qm` in QM partition, no other input.
+
+    Test inputs:
+        None
+
+    Expected results:
+        out: [ INFO  ] PASS: check_usr_share_qm_not_accessible: As expected, /usr/share/qm is not accessible in the QM partition.
+
+    Results location:
+        output.txt
 test: /bin/bash ./check_usr_share_qm.sh
 duration: 10m
 tag: ffi

--- a/tests/ffi/attempts_to_access_forbidden_file_system_resource/shared_memory_files/check_dev_shm.fmf
+++ b/tests/ffi/attempts_to_access_forbidden_file_system_resource/shared_memory_files/check_dev_shm.fmf
@@ -1,5 +1,21 @@
 summary: Test that the file created in /dev/shm/ outside the QM partition that are
     not visible in /dev/shm inside the QM partition.
+description: |
+    This tests confirms that the file created in /dev/shm/ outside the QM partition that are
+    not visible in /dev/shm inside the QM partition.
+    The test creates a file outside QM partition using `touch /dev/shm/on-host` and tests if it
+    was succesfully creted using `test -e /dev/shm/on-host`.
+    Then the test checks to confirm  that the file /dev/shm/on-host is not visible inside
+    the QM partition using `test -e /dev/shm/on-host`
+    Test inputs:
+        None
+
+    Expected results:
+        out: [ INFO  ] Successfully created the file /dev/shm/on-host outside the QM partition.
+             [ INFO  ] PASS: check_dev_shm_file_not_visible_in_qm: As expected, /dev/shm/on-host is not visible in the QM partition.
+
+    Results location:
+        output.txt
 test: /bin/bash ./check_dev_shm.sh
 duration: 10m
 tag: ffi

--- a/tests/ffi/attempts_to_access_forbidden_file_system_resource/sockets/check_run_systemd_journal_socket.fmf
+++ b/tests/ffi/attempts_to_access_forbidden_file_system_resource/sockets/check_run_systemd_journal_socket.fmf
@@ -1,5 +1,19 @@
 summary: Test that /run/systemd/journal/socket have different inode number inside
     and outside of the QM partition.
+description: |
+    This tests confirms that /run/systemd/journal/socket have different inode number inside
+    and outside of the QM partition.
+    The test gets inode number of /run/systemd/journal/socket inside and outside of the QM partition
+    using `stat --printf='%i' /run/systemd/journal/socket` and `podman exec qm stat --printf='%i' /run/systemd/journal/socket`
+    respectively and checks to ensure these are different values.
+    Test inputs:
+        None
+
+    Expected results:
+        out: [ INFO  ] PASS: check_run_systemd_journal_socket_inode_number: As expected, /run/systemd/journal/socket have different inode number inside and outside of the QM partition
+
+    Results location:
+        output.txt
 test: /bin/bash ./check_run_systemd_journal_socket.sh
 duration: 10m
 tag: ffi

--- a/tests/ffi/attempts_to_access_forbidden_file_system_resource/sockets/check_run_udev_control.fmf
+++ b/tests/ffi/attempts_to_access_forbidden_file_system_resource/sockets/check_run_udev_control.fmf
@@ -1,4 +1,15 @@
 summary: Test that the socket /run/udev/control does not exist in the QM partition.
+description: |
+    This tests confirms that the socket /run/udev/control does not exist in the QM partition.
+    The test executes `test -e /run/udev/control` in QM partition, no other input.
+
+    Test inputs:
+        None
+
+    Expected results:
+        out: [ INFO  ] PASS: check_run_udev_control_not_exist: As expected, /run/udev/control dose not exist in the QM partition
+    Results location:
+        output.txt
 test: /bin/bash ./check_run_udev_control.sh
 duration: 10m
 tag: ffi

--- a/tests/ffi/dev_mem_not_present/main.fmf
+++ b/tests/ffi/dev_mem_not_present/main.fmf
@@ -1,4 +1,16 @@
 summary: Test /dev/mem is not present in QM partition.
+description: |
+    This tests confirms that /dev/mem is not present in QM partition.
+    The test executes `test -e /dev/mem` in QM partition, no other input.
+
+    Test inputs:
+        None
+
+    Expected results:
+        out: [ INFO  ] PASS: check_dev_mem_not_present: As expected, /dev/mem is not present in QM partition.
+
+    Results location:
+        output.txt
 test: /bin/bash ./test.sh
 duration: 10m
 tag: ffi


### PR DESCRIPTION
Test metadata information was added to the following cases:

- https://github.com/containers/qm/tree/main/tests/ffi/attempts_to_access_forbidden_file_system_resource
- https://github.com/containers/qm/tree/main/tests/ffi/dev_mem_not_present
- https://github.com/containers/qm/tree/main/tests/ffi/sys_read_only