### PR TITLE
Add bluechi uds to policy

### DIFF
--- a/qm.te
+++ b/qm.te
@@ -29,3 +29,12 @@ files_pid_filetrans(init_t, ipc_var_run_t, dir, "ipc")
 unconfined_domain(ipc_t)
 
 qm_domain_template(qm)
+
+optional_policy(`
+	require{
+		type bluechi_var_run_t;
+		type bluechi_t;
+	}
+	stream_connect_pattern(qm_t, bluechi_var_run_t, bluechi_var_run_t, bluechi_t)
+	unconfined_server_stream_connectto(qm_t)
+')

--- a/rpm/qm.spec
+++ b/rpm/qm.spec
@@ -71,7 +71,6 @@ Requires(post): selinux-policy-targeted >= %_selinux_policy_version
 Requires(post): policycoreutils
 Requires(post): libselinux-utils
 Requires: podman >= %{podman_epoch}:4.5
-Requires: bluechi-agent
 Requires: jq
 
 %description

--- a/rpm/qm.spec
+++ b/rpm/qm.spec
@@ -61,6 +61,7 @@ BuildRequires: git-core
 BuildRequires: pkgconfig(systemd)
 BuildRequires: selinux-policy >= %_selinux_policy_version
 BuildRequires: selinux-policy-devel >= %_selinux_policy_version
+BuildRequires: bluechi-selinux
 
 Requires: iptables
 Requires: parted


### PR DESCRIPTION
Fixes: https://github.com/containers/qm/issues/677
    
Recently, BlueChi enhanced the support for Unix Domain Sockets, including the respective SELinux policy (see In eclipse-bluechi/bluechi#1015). On a setup QM + BlueChi it makes sense to mount the UDS of BlueChi into QM and have the bluechi-agent inside connect to it. This, however, is currently rejected due to missing SELinux policy rules. Let's add this rule.