### PR TITLE
Add jq package installation to a-i-b test

### DIFF
--- a/plans/e2e/aib.fmf
+++ b/plans/e2e/aib.fmf
@@ -4,6 +4,13 @@ discover:
     how: fmf
     filter: 'tag:aib'
 
+prepare:
+  - name: Install packages
+    how: install
+    order: 20
+    package:
+      - jq
+
 execute:
     how: tmt
 


### PR DESCRIPTION
auto-image-builder.sh now uses jq. Adding jq to the prepare step for automotive-image-builder test plan