### PR TITLE
rename /usr/share/qm/seccomp.json

### DIFF
--- a/create-seccomp-rules
+++ b/create-seccomp-rules
@@ -17,7 +17,7 @@
 SECCOMP_CONTAINERS_FILE="/usr/share/containers/seccomp.json"
 SYSCALLS_TO_DENY=("sched_setscheduler" "sched_setattr")
 
-QM_PATH_SECCOMP="/usr/share/qm/seccomp.json"
+QM_PATH_SECCOMP="/usr/share/qm/seccomp-no-rt.json"
 QM_DIR="${QM_PATH_SECCOMP%/*}"
 
 function remove_seccomp_entry_from_allow() {

--- a/qm.container
+++ b/qm.container
@@ -50,7 +50,7 @@ AddCapability=all
 # For details see: https://docs.podman.io/en/latest/markdown/podman-systemd.unit.5.html#unmask
 Unmask=ALL
 SecurityLabelNested=true
-SeccompProfile=/usr/share/qm/seccomp.json
+SeccompProfile=/usr/share/qm/seccomp-no-rt.json
 
 # PidsLimit
 # ---------

--- a/rpm/qm.spec
+++ b/rpm/qm.spec
@@ -10,7 +10,7 @@
 %global selinuxtype targeted
 %global moduletype services
 %global modulenames qm
-%global seccomp_json /usr/share/%{modulenames}/seccomp.json
+%global seccomp_json /usr/share/%{modulenames}/seccomp-no-rt.json
 %global setup_tool %{_prefix}/share/%{modulenames}/setup
 
 %global _installscriptdir %{_prefix}/lib/%{modulenames}

--- a/tests/e2e/tools/FFI/deny_sched_setattr/README.md
+++ b/tests/e2e/tools/FFI/deny_sched_setattr/README.md
@@ -11,7 +11,7 @@ and must validated via FFI tests.
 
 ## How to deny is made?
 
-During the QM service startup it passes arguments to Podman. One of these arguments is `seccomp=/usr/share/qm/seccomp.json` which contains rules that deny the `sched_setattr()`.
+During the QM service startup it passes arguments to Podman. One of these arguments is `seccomp=/usr/share/qm/seccomp-no-rt.json` which contains rules that deny the `sched_setattr()`.
 
 ## How to test?
 

--- a/tests/e2e/tools/FFI/deny_set_scheduler/README.md
+++ b/tests/e2e/tools/FFI/deny_set_scheduler/README.md
@@ -8,7 +8,7 @@ QM environment deny `set_scheduler()` syscall for safety and must be validated v
 
 ## How to deny is made?
 
-During the QM service startup it passes arguments to Podman. One of these arguments is `seccomp=/usr/share/qm/seccomp.json` which contains rules that deny the `set_scheduler()`.
+During the QM service startup it passes arguments to Podman. One of these arguments is `seccomp=/usr/share/qm/seccomp-no-rt.json` which contains rules that deny the `set_scheduler()`.
 
 ## How to test?
 

--- a/tests/ffi/disk/test.sh
+++ b/tests/ffi/disk/test.sh
@@ -33,7 +33,7 @@ OOMScoreAdjust=1000
 
 [Container]
 PodmanArgs=
-PodmanArgs=--pids-limit=-1 --security-opt seccomp=/usr/share/qm/seccomp.json --security-opt label=nested --security-opt unmask=all --memory 5G
+PodmanArgs=--pids-limit=-1 --security-opt seccomp=/usr/share/qm/seccomp-no-rt.json --security-opt label=nested --security-opt unmask=all --memory 5G
 
 EOF
 


### PR DESCRIPTION
To be explicit the current seccomp.json
DO NOT support realtime (rt) sched we will
add it into the name of the file.