### PR TITLE
containers.conf: Set a different default ip subnet for qm containers

### DIFF
--- a/containers.conf
+++ b/containers.conf
@@ -18,3 +18,8 @@ cgroup_conf=[
 # OOMScoreAdjust=500
 #
 oom_score_adj = 750
+
+[network]
+# The default is 10.88.0.0, but we need qm containers to have a
+# different ip address range or routing becomes confused
+default_subnet="10.89.0.0/16"


### PR DESCRIPTION
Otherwise both host and qm containers have the same range and things get confused.

resolve #714 

## Summary by Sourcery

Enhancements:
- Configures a different default IP subnet for qm containers.