### PR TITLE
Updating release build for c10s

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -138,12 +138,14 @@ jobs:
     dist_git_branches:
       - fedora-all
       - epel-9
+      - epel-10
 
   - job: koji_build
     trigger: commit
     dist_git_branches:
       - fedora-all
       - epel-9
+      - epel-10
 
   - job: bodhi_update
     trigger: commit
@@ -151,3 +153,4 @@ jobs:
       # rawhide updates are created automatically
       - fedora-branched
       - epel-9
+      - epel-10


### PR DESCRIPTION
I hope this finally close c10s release by packit 
#677

## Summary by Sourcery

Build:
- Add epel-10 branch to the release build configuration.