### PR TITLE
Fix suport for CPUWeight

### DIFF
--- a/demos/demo
+++ b/demos/demo
@@ -105,20 +105,15 @@ status() {
 }
 
 cpuweight() {
-    exec_color "sudo systemctl set-property --runtime QM.slice CPUWeight=50"
     exec_color "sudo systemctl set-property --runtime qm.service CPUWeight=50"
 
-    echo "Value stored in QM.slice/cpu.weight:"
-    sudo cat /sys/fs/cgroup/QM.slice/cpu.weight
+    echo "Value stored in qm.service/cpu.weight:"
+    sudo cat /sys/fs/cgroup/qm.service/cpu.weight
 
-    echo "Value stored in QM.slice/qm.service/cpu.weight:"
-    sudo cat /sys/fs/cgroup/QM.slice/qm.service/cpu.weight
-    exec_color "sudo systemctl set-property --runtime QM.slice CPUWeight=10"
+    exec_color "sudo systemctl set-property --runtime qm.service CPUWeight=10"
 
-    echo "Value stored in QM.slice/cpu.weight:"
-    sudo cat /sys/fs/cgroup/QM.slice/cpu.weight
-    echo "Value stored in QM.slice/qm.service/cpu.weight:"
-    sudo cat /sys/fs/cgroup/QM.slice/qm.service/cpu.weight
+    echo "Value stored in qm.service/cpu.weight:"
+    sudo cat /sys/fs/cgroup/qm.service/cpu.weight
     echo -e "\n\n[Press enter to continue]"
     read -r
 }

--- a/docs/devel/README.md
+++ b/docs/devel/README.md
@@ -156,7 +156,7 @@ ago
       Tasks: 7 (limit: 7772)
      Memory: 82.1M (swap max: 0B)
         CPU: 945ms
-     CGroup: /QM.slice/qm.service
+     CGroup: /qm.service
              ├─libpod-payload-a83253ae278d7394cb38e975535590d71de90a41157b547040
 4abd6311fd8cca
              │ ├─init.scope

--- a/qm.8.md
+++ b/qm.8.md
@@ -40,7 +40,7 @@ systemctl status qm.service
       Tasks: 11 (limit: 76801)
      Memory: 275.1M (swap max: 0B)
         CPU: 4.527s
-     CGroup: /QM.slice/qm.service
+     CGroup: /qm.service
              ├─libpod-payload-00de006493bc970788d6c830beb494a58a9a2847a5eda200812d3a8b4e214814
              │ ├─init.scope
              │ │ └─993676 /sbin/init
@@ -53,11 +53,13 @@ systemctl status qm.service
 ...
 ```
 
-## CGROUPS QM.slice
+## CGroups and container configuration
 
-Notice that the QM environment is running systemd and other services within the
-QM.Slice. This slice can be used to modify the cgroups controls of all of the
-processes within the QM environment.
+The options in the qm.container file overridden by using drop-in files, in the
+directories `/etc/containers/systemd/qm.container.d` or`
+`/usr/lib/containers/systemd/qm.container.d. This allows overriding for example
+CGroup options like Service.CPUWeight, or podman options like Container.Volume.
+Such options will affect all the processes running in the qm container.
 
 ## Install Additional packages in QM
 

--- a/qm.container
+++ b/qm.container
@@ -34,7 +34,10 @@ MemorySwapMax=0
 # Containers within the qm contain default set OOMScoreAdj to 750
 OOMScoreAdjust=500
 Restart=always
-Slice=QM.slice
+# qm.service is a toplevel cgroup, so CPUWeight is relative to all other cgroups in that
+# parent (such as user.slice and system.slice), otherwise the CPUWeight of qm.service
+# is only compared to the other children of its parent.
+Slice=-.slice
 Environment=ROOTFS=/usr/lib/qm/rootfs
 Environment=RWETCFS=/etc/qm
 Environment=RWVARFS=/var/qm


### PR DESCRIPTION
In the current setup, qm.service is part of the QM.slice. This means that the CPUWeight of qm.service is only applied against the other groups of QM.slice, i.e. none. This means CPUWeight does nothing.

Here change the parent of qm.service to be -.service (the root cgroup), which means that the weight of it will be compared to the other toplevel slices, which normally is user.slice and system.slice.

So, with the current default CPUWeight in qm.container of 50, and the default weight of 100, this means that qm.service now will get half the cpu of the processes in system.slice, which is the intent.

I tried this by running "openssl speed --seconds 99999" both inside qm and outside it one a one-cpu VM, and before both processes always got 50% cpu, but now they are split up according to CPUWeight in the qm.container.

## Summary by Sourcery

Bug Fixes:
- CPUWeight of qm.service was not being applied correctly because it was only being compared against other groups in QM.slice.