### PR TITLE
Improve safety in qm virtual filesystems

### DIFF
--- a/containers.conf
+++ b/containers.conf
@@ -6,6 +6,10 @@ cgroup_conf=[
 	"memory.oom.group=1",
 ]
 
+# Temporary default to host network until we fix private network bridge setup
+# when the qm container doesn't unmask all the virtual filesystems.
+netns="host"
+
 # The om_score_adj refers to the "Out of Memory score adjustment" in Linux
 # operating systems. This parameter is used by the Out of Memory (OOM)
 # killer to decide which processes to terminate when the system is

--- a/qm.container
+++ b/qm.container
@@ -53,12 +53,6 @@ TasksMax=50%
 # For details see: https://docs.podman.io/en/latest/markdown/podman-systemd.unit.5.html#addcapability
 AddCapability=all
 
-# Unmask
-# -------
-# Specify the paths to unmask separated by a colon. unmask=ALL or /path/1:/path/2, or shell expanded paths (/proc/*):
-# If set to ALL, Podman will unmask all the paths that are masked or made read-only by default.
-# For details see: https://docs.podman.io/en/latest/markdown/podman-systemd.unit.5.html#unmask
-Unmask=ALL
 SecurityLabelNested=true
 SeccompProfile=/usr/share/qm/seccomp-no-rt.json
 


### PR DESCRIPTION
- Removed `Unmask=ALL` from the qm.container file to enhance safety for qm virtual filesystems. Unmasking all virtual file systems results in many virtual file systems being mounted on the qm container with read and write permissions that allow qm processes to interact with them.
- Set `netns="host"` as the default configuration in the `containers.conf`.

A bit background on this. To guarantee FFI we can't have all the
sensitive pseudo-filesystems like /proc/sys and /sys fully available
inside QM. However, unfortunately currently this is needed for podman to
set up the network bridge when doing --network=private. It fails setting
some network sysctl options. For now we hack-fix this by making
non-private network default, because FFI is more important than podman
features.

However, we think long term this is fixable by granting setting some
sysctls by default in the qm container and possibly granting specific
access to safe sysctls. we did some initial work on this and got part of
the way there, but we don't have a full solution yet.

## Summary by Sourcery

Improve the safety of qm virtual filesystems by removing `Unmask=ALL` and setting `netns="host"` as the default configuration in the `containers.conf`.

Chores:
- Remove `Unmask=ALL` from the qm.container file to enhance safety for qm virtual filesystems.
- Set `netns="host"` as the default configuration in the `containers.conf`.