### PR TITLE
Change CPUWeight default to "idle"

### DIFF
--- a/qm.container
+++ b/qm.container
@@ -11,7 +11,7 @@ WantedBy=default.target
 # ManagedOOMSwap=auto|kill: Specifies how systemd-oomd.service will act on qm.
 # QM cgroup, pass directly to systemd and handled by it,
 # please refer to `man systemd.resource-control` for details.
-CPUWeight=50
+CPUWeight=idle
 Delegate=true
 IOWeight=50
 ManagedOOMSwap=kill


### PR DESCRIPTION
This default means that the QM partition only gets CPU if nothing is wants to run on the rest of the system. Essentially it gets SCHED_IDLE behaviour.

## Summary by Sourcery

Enhancements:
- Change the default CPUWeight setting to 'idle' for the QM partition, ensuring it only receives CPU resources when the rest of the system is idle.