### PR TITLE
qm.te: add selinux rules to libvirtd start

### DIFF
--- a/qm.te
+++ b/qm.te
@@ -4,6 +4,7 @@ gen_require(`
 	attribute container_file_type;
 	attribute container_runtime_domain;
 	type init_t;
+	type virtd_unit_file_t;
 ')
 
 type ipc_t;
@@ -29,6 +30,9 @@ files_pid_filetrans(init_t, ipc_var_run_t, dir, "ipc")
 unconfined_domain(ipc_t)
 
 qm_domain_template(qm)
+
+# Add policy to allow qm_t to access virtd_unit_file_t
+allow qm_t virtd_unit_file_t:file { read open ioctl };
 
 optional_policy(`
 	require{


### PR DESCRIPTION
libvirt service is getting permission denied

```
type=AVC msg=audit(1742306133.441:7198): avc:  denied  { read } for  pid=26752 comm="systemd" name="libvirtd.service" dev="vda3" ino=458763 scontext=system_u:system_r:qm_t:s0 tcontext=system_u:object_r:virtd_unit_file_t:s0 tclass=file permissive=1
    Was caused by:
        Missing type enforcement (TE) allow rule.
        You can use audit2allow to generate a loadable module to allow this access.
type=AVC msg=audit(1742306133.441:7199): avc:  denied  { open } for  pid=26752 comm="systemd" path="/usr/lib/systemd/system/libvirtd.service" dev="vda3" ino=458763 scontext=system_u:system_r:qm_t:s0 tcontext=system_u:object_r:virtd_unit_file_t:s0 tclass=file permissive=1
    Was caused by:
        Missing type enforcement (TE) allow rule.
        You can use audit2allow to generate a loadable module to allow this access.
type=AVC msg=audit(1742306133.441:7200): avc:  denied  { ioctl } for  pid=26752 comm="systemd" path="/usr/lib/systemd/system/libvirtd.service" dev="vda3" ino=458763 ioctlcmd=0x5401 scontext=system_u:system_r:qm_t:s0 tcontext=system_u:object_r:virtd_unit_file_t:s0 tclass=file permissive=1
    Was caused by:
        Missing type enforcement (TE) allow rule.
        You can use audit2allow to generate a loadable module to allow this access.
type=AVC msg=audit(1742306133.442:7201): avc:  denied  { read } for  pid=26752 comm="systemd" name="iscsid.service" dev="vda3" ino=450573 scontext=system_u:system_r:qm_t:s0 tcontext=system_u:object_r:iscsi_unit_file_t:s0 tclass=file permissive=1
    Was caused by:
        Missing type enforcement (TE) allow rule.
        You can use audit2allow to generate a loadable module to allow this access.
```

## Summary by Sourcery

Bug Fixes:
- Fixes permission denied errors when starting libvirtd service.