### PR TITLE
CODEOWNERS: remove lsm5

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
 # Default to all maintainers if nothing more specific matches
-* @rhatdan @lsm5 @dougsland @yarboa @sandrobonazzola @nsednev @aesteve-rh @pengshanyu @kleinffm
+* @rhatdan @dougsland @yarboa @sandrobonazzola @nsednev @aesteve-rh @pengshanyu @kleinffm


### PR DESCRIPTION
I am not actively involved in the project.

## Summary by Sourcery

Chores:
- Remove lsm5 from CODEOWNERS.