### PR TITLE
Added network README.md for network options using quadlets.

### DIFF
--- a/docs/quadlet-examples/network/README.md
+++ b/docs/quadlet-examples/network/README.md
@@ -1,0 +1,35 @@
+# Here is an example of running a network-test container using quadlets for both --network=host and --network=private
+
+You should place this file either in /usr/share/containers/systemd/ or /etc/containers/systemd/
+
+```console
+/usr/share/containers/systemd/
+/etc/containers/systemd/
+```
+
+For rootless users:
+
+```console
+$HOME/.config/containers/systemd/
+
+```
+
+Host Network
+
+```console
+# network-test.container
+[Container]
+ContainerName=network-test
+Image=localhost/local-audio-image
+Network=host
+```
+
+Private Network
+
+```console
+# network-test.container
+[Container]
+ContainerName=network-test
+Image=localhost/local-audio-image
+Network=private
+```

--- a/docs/tutorials/NETWORK.md
+++ b/docs/tutorials/NETWORK.md
@@ -42,3 +42,5 @@ podman run -it --network=private fedora /bin/bash
 In the first example, the container will share the host's network namespace, while in the second example, the container will have its own isolated network namespace.
 
 For more information, see the [Podman Networking Tutorial](https://github.com/containers/podman/blob/main/docs/tutorials/basic_networking.md).
+
+For network modes configuration example using quadlets, see [Qaudlet Network Example](https://github.com/containers/qm/blob/main/docs/quadlet-examples/network/README.md).


### PR DESCRIPTION
Here is an example of running a network-test container using quadlets for both --network=host and --network=private.
This is a README file as was requested in https://github.com/containers/qm/issues/717 .

## Summary by Sourcery

Documentation:
- Create a README.md file demonstrating how to configure container networks using quadlets, showing examples for host and private network modes