### PR TITLE
Restrict access to the mounted socket to bluechi-agent

### DIFF
--- a/qm.fc
+++ b/qm.fc
@@ -11,3 +11,6 @@
 
 # File context for ipc programs
 /var/run/ipc(/.*)?	gen_context(system_u:object_r:ipc_var_run_t,s0)
+
+# File context for bluechi-agent inside QM
+/usr/lib/qm/rootfs/usr/libexec/bluechi-agent	--	gen_context(system_u:object_r:qm_bluechi_agent_exec_t,s0)

--- a/qm.te
+++ b/qm.te
@@ -35,6 +35,11 @@ optional_policy(`
 		type bluechi_var_run_t;
 		type bluechi_t;
 	}
-	stream_connect_pattern(qm_t, bluechi_var_run_t, bluechi_var_run_t, bluechi_t)
-	unconfined_server_stream_connectto(qm_t)
+
+	type qm_bluechi_agent_t;
+	type qm_bluechi_agent_exec_t;
+	init_daemon_domain(qm_bluechi_agent_t, qm_bluechi_agent_exec_t)
+
+	stream_connect_pattern(qm_bluechi_agent_t, bluechi_var_run_t, bluechi_var_run_t, bluechi_t)
+	unconfined_server_stream_connectto(qm_bluechi_agent_t)
 ')


### PR DESCRIPTION
This limits the access to the mounted Unix Domain Socket of BlueChi into QM further so that inside QM only bluechi-agent can use the socket.

## Summary by Sourcery

Enhancements:
- Implement more granular access controls for the BlueChi socket in the QM SELinux policy