### PR TITLE
Container systemd-audio is not running in QM

### DIFF
--- a/rpm/sound/sound.spec
+++ b/rpm/sound/sound.spec
@@ -1,10 +1,10 @@
 %global debug_package %{nil}
 
 # Define the rootfs macros
-%global rootfs_qm %{_prefix}/lib/qm/rootfs/
+%define qm_sysconfdir %{_sysconfdir}/qm
 
 Name: qm-sound
-Version: 0
+Version: %{version}
 Release: 1%{?dist}
 Summary: Drop-in configuration for QM containers to mount bind /dev/snd
 License: GPL-2.0-only
@@ -29,9 +29,10 @@ the container and nested containers.
 # Install drop-in configuration for /dev/snd
 # Create the directory for drop-in configurations
 install -d %{buildroot}%{_sysconfdir}/containers/systemd/qm.container.d
-install -d %{buildroot}%{rootfs_qm}%{_sysconfdir}/containers/systemd
+install -d %{buildroot}%{qm_sysconfdir}/containers/systemd
 
-install -m 644 %{_builddir}/qm-sound-%{version}/subsystems/sound/etc/containers/systemd/audio.container %{buildroot}%{rootfs_qm}%{_sysconfdir}/containers/systemd/audio.container
+install -m 644 %{_builddir}/qm-sound-%{version}/subsystems/sound/etc/containers/systemd/audio.container \
+    %{buildroot}%{qm_sysconfdir}/containers/systemd/audio.container
 # Install the sound drop-in configuration file
 install -m 644 %{_builddir}/qm-sound-%{version}/etc/containers/systemd/qm.container.d/qm_dropin_mount_bind_snd.conf \
     %{buildroot}%{_sysconfdir}/containers/systemd/qm.container.d/qm_dropin_mount_bind_snd.conf
@@ -40,7 +41,7 @@ install -m 644 %{_builddir}/qm-sound-%{version}/etc/containers/systemd/qm.contai
 %license LICENSE
 %doc README.md SECURITY.md
 %{_sysconfdir}/containers/systemd/qm.container.d/qm_dropin_mount_bind_snd.conf
-%{rootfs_qm}%{_sysconfdir}/containers/systemd/audio.container
+%{qm_sysconfdir}/containers/systemd/audio.container
 
 %changelog
 * Fri Jul 21 2023 RH Container Bot <rhcontainerbot@fedoraproject.org>

--- a/subsystems/sound/Makefile
+++ b/subsystems/sound/Makefile
@@ -7,13 +7,19 @@ SPECFILE_SUBPACKAGE_SOUND ?= ${ROOTDIR}/rpm/sound/sound.spec
 dist: ##             - Creates the QM sound package
 	cd $(ROOTDIR) && tar cvz \
 		--dereference \
-		--transform s/qm/qm-sound-${VERSION}/ \
+		--transform 's|subsystems/kvm/Makefile|Makefile|' \
+		--transform 's|rpm/sound/sound.spec|qm-sound.spec|' \
+		--transform 's|qm|qm-sound-${VERSION}|' \
 		-f /tmp/qm-sound-${VERSION}.tar.gz \
+		../qm/rpm/sound/sound.spec \
+		../qm/subsystems/sound/Makefile \
+		../qm/tools/version-update \
 		../qm/README.md \
 		../qm/SECURITY.md \
 		../qm/LICENSE \
 		../qm/etc/containers/systemd/qm.container.d/qm_dropin_mount_bind_snd.conf \
 		../qm/subsystems/sound/etc/containers/systemd/audio.container
+
 	cd $(ROOTDIR) && mv /tmp/qm-sound-${VERSION}.tar.gz ./rpm
 
 .PHONY: sound

--- a/subsystems/sound/etc/containers/systemd/audio.container
+++ b/subsystems/sound/etc/containers/systemd/audio.container
@@ -4,6 +4,7 @@ After=network.target
 
 [Container]
 Image=quay.io/qm-images/audio:latest
+Network=host
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This MR will fix the problem of systemd-audio container not runnig after qm is up

Closes https://github.com/containers/qm/issues/771
Closes https://github.com/containers/qm/issues/770
Signed-off-by: Artiom Divak <adivak@redhat.com>

## Summary by Sourcery

Bug Fixes:
- Resolve the problem preventing the systemd-audio container from running after QM startup
- Fix sound rpm