### PR TITLE
subpackage: adjust spec for subpackage video

### DIFF
--- a/rpm/video/video.spec
+++ b/rpm/video/video.spec
@@ -1,10 +1,10 @@
 %global debug_package %{nil}
 
 # Define the rootfs macros
-%global rootfs_qm %{_prefix}/lib/qm/rootfs/
+%define qm_sysconfdir %{_sysconfdir}/qm
 
 Name: qm-mount-bind-video
-Version: 0
+Version: %{version}
 Release: 1%{?dist}
 Summary: Drop-in configuration for QM containers to mount bind /dev/video
 License: GPL-2.0-only
@@ -26,10 +26,11 @@ This subpackage installs a drop-in configuration for QM containers to mount bind
 %install
 # Create the directory for drop-in configurations
 install -d %{buildroot}%{_sysconfdir}/containers/systemd/qm.container.d
-install -d %{buildroot}%{rootfs_qm}%{_sysconfdir}/containers/systemd
+install -d %{buildroot}%{qm_sysconfdir}/containers/systemd
 
-install -m 644 %{_builddir}/qm-video-%{version}/subsystems/video/etc/containers/systemd/rear-camera.container %{buildroot}%{rootfs_qm}%{_sysconfdir}/containers/systemd/rear-camera.container
-# Install the sound drop-in configuration file
+install -m 644 %{_builddir}/qm-video-%{version}/subsystems/video/etc/containers/systemd/rear-camera.container \
+     %{buildroot}%{qm_sysconfdir}/containers/systemd/rear-camera.container
+
 install -m 644 %{_builddir}/qm-video-%{version}/etc/containers/systemd/qm.container.d/qm_dropin_mount_bind_video.conf \
     %{buildroot}%{_sysconfdir}/containers/systemd/qm.container.d/qm_dropin_mount_bind_video.conf
 
@@ -37,7 +38,7 @@ install -m 644 %{_builddir}/qm-video-%{version}/etc/containers/systemd/qm.contai
 %license LICENSE
 %doc README.md SECURITY.md
 %{_sysconfdir}/containers/systemd/qm.container.d/qm_dropin_mount_bind_video.conf
-%{rootfs_qm}%{_sysconfdir}/containers/systemd/rear-camera.container
+%{qm_sysconfdir}/containers/systemd/rear-camera.container
 
 %changelog
 * Fri Jul 21 2023 RH Container Bot <rhcontainerbot@fedoraproject.org>

--- a/subsystems/video/etc/containers/systemd/rear-camera.container
+++ b/subsystems/video/etc/containers/systemd/rear-camera.container
@@ -13,3 +13,4 @@ WantedBy=multi-user.target
 Image=quay.io/qm-images/multimedia:latest
 Exec=fswebcam -r 1024x768 --jpeg 100 /tmp/screenshot.jpg
 Volume=/tmp:/tmp
+AddDevice=-/dev/video0


### PR DESCRIPTION
- adjust spec for subpackage video
- add AddDevice=-/dev/video into the container file

## Summary by Sourcery

Modify the video subpackage specification to adjust installation paths and versioning

Enhancements:
- Update the spec file to use a dynamic version instead of a hardcoded version
- Refactor installation paths to use a more standard system configuration directory

Chores:
- Simplify the installation process for video-related container configurations