### PR TITLE
Added AddDevice=/dev/snd

### DIFF
--- a/subsystems/sound/etc/containers/systemd/audio.container
+++ b/subsystems/sound/etc/containers/systemd/audio.container
@@ -5,6 +5,7 @@ After=network.target
 [Container]
 Image=quay.io/qm-images/audio:latest
 Network=host
+AddDevice=/dev/snd
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This MR is a corection for https://github.com/containers/qm/pull/783

related
closes https://github.com/containers/qm/issues/771
Signed-off-by: Artiom Divak <adivak@redhat.com>

## Summary by Sourcery

Add sound device support for containers by configuring AddDevice for /dev/snd

New Features:
- Enable sound device access in container configurations

Bug Fixes:
- Resolve audio device access limitations for containers