### PR TITLE
subpackage: fix path for ros2

### DIFF
--- a/rpm/dvb/dvb.spec
+++ b/rpm/dvb/dvb.spec
@@ -1,8 +1,5 @@
 %global debug_package %{nil}
 
-# Define the rootfs macros
-%global rootfs_qm %{_prefix}/lib/qm/rootfs/
-
 Name: qm-mount-bind-dvb
 Version: 0
 Release: 1%{?dist}

--- a/rpm/ros2/ros2_rolling.spec
+++ b/rpm/ros2/ros2_rolling.spec
@@ -1,10 +1,9 @@
 %global debug_package %{nil}
 
-# rootfs macros for QM ROS2 Rolling
-%global rootfs_qm %{_prefix}/lib/qm/rootfs/
+%define qm_sysconfdir %{_sysconfdir}/qm
 
 Name: qm-ros2-rolling
-Version: 0
+Version: %{version}
 Release: 1%{?dist}
 Summary: Subpackage container for quadlet container to ROS2 Rolling environment
 License: GPL-2.0-only
@@ -27,16 +26,17 @@ containers managed by Podman and systemd within the QM environment.
 
 %install
 # Create the necessary directory structure
-install -d %{buildroot}%{rootfs_qm}%{_sysconfdir}/containers/systemd
+install -d %{buildroot}%{qm_sysconfdir}/containers/systemd
 
 # Install the ROS2 Rolling container file
-install -m 644 %{_builddir}/qm-ros2-%{version}/subsystems/ros2/etc/containers/systemd/ros2-rolling.container %{buildroot}%{rootfs_qm}%{_sysconfdir}/containers/systemd/ros2-rolling.container
+install -m 644 %{_builddir}/qm-ros2-%{version}/subsystems/ros2/etc/containers/systemd/ros2-rolling.container \
+      %{buildroot}%{qm_sysconfdir}/containers/systemd/ros2-rolling.container
 
 
 %files
 %license LICENSE
 %doc README.md SECURITY.md
-%{rootfs_qm}%{_sysconfdir}/containers/systemd/ros2-rolling.container
+%{qm_sysconfdir}/containers/systemd/ros2-rolling.container
 
 
 %changelog

--- a/rpm/text2speech/text2speech.spec
+++ b/rpm/text2speech/text2speech.spec
@@ -1,8 +1,5 @@
 %global debug_package %{nil}
 
-# Define rootfs macro for QM environment
-%global rootfs_qm %{_prefix}/lib/qm/rootfs/
-
 Name: qm-text2speech
 Version: 0
 Release: 1%{?dist}


### PR DESCRIPTION
- Remove old reference for qm_rootfs
- adjust ros2 for subpackage

## Summary by Sourcery

Remove old QM rootfs references and adjust ROS2 subpackage configuration paths

Bug Fixes:
- Remove deprecated rootfs macro references across multiple spec files

Enhancements:
- Update ROS2 rolling spec file to use standard system configuration directory