### PR TITLE
subpackages: adjust path and remove qm_rootfs

### DIFF
--- a/rpm/windowmanager/windowmanager.spec
+++ b/rpm/windowmanager/windowmanager.spec
@@ -1,9 +1,9 @@
 # Define the rootfs macros
-%global rootfs_qm %{_prefix}/lib/qm/rootfs/
+%define qm_sysconfdir %{_sysconfdir}/qm
 
 
 Name: qm-windowmanager
-Version: 0
+Version: %{version}
 Release: 1%{?dist}
 Summary: Optional Window Manager for QM environment
 License: GPL-2.0-only
@@ -23,23 +23,23 @@ This sub-package installs an experimental window manager for the QM environment.
 # Create the directory for drop-in configurations
 install -d  %{buildroot}/%{_sysconfdir}/pam.d/
 install -d %{buildroot}%{_sysconfdir}/containers/systemd/qm.container.d
-install -d %{buildroot}%{rootfs_qm}%{_sysconfdir}/containers/systemd
+install -d %{buildroot}%{qm_sysconfdir}/containers/systemd
 
 # Install the Window manager drop-in configuration file
 install -m 644 %{_builddir}/qm-windowmanager-%{version}/etc/containers/systemd/qm.container.d/qm_dropin_mount_bind_window_manager.conf \
     %{buildroot}%{_sysconfdir}/containers/systemd/qm.container.d/qm_dropin_mount_bind_window_manager.conf
 install -m 644 %{_builddir}/qm-windowmanager-%{version}/subsystems/windowmanager/etc/pam.d/wayland %{buildroot}/%{_sysconfdir}/pam.d/
-install -m 644 %{_builddir}/qm-windowmanager-%{version}/subsystems/windowmanager/etc/containers/systemd/* %{buildroot}%{rootfs_qm}%{_sysconfdir}/containers/systemd/
+install -m 644 %{_builddir}/qm-windowmanager-%{version}/subsystems/windowmanager/etc/containers/systemd/* %{buildroot}%{qm_sysconfdir}/containers/systemd/
 
 %files
 %license LICENSE
 %doc README.md
 %{_sysconfdir}/pam.d/wayland
 %{_sysconfdir}/containers/systemd/qm.container.d/qm_dropin_mount_bind_window_manager.conf
-%{rootfs_qm}%{_sysconfdir}/containers/systemd/gnome_mutter.container
-%{rootfs_qm}%{_sysconfdir}/containers/systemd/session-activate.container
-%{rootfs_qm}%{_sysconfdir}/containers/systemd/wayland-extra-devices.conf
-%{rootfs_qm}%{_sysconfdir}/containers/systemd/weston_terminal.container
+%{qm_sysconfdir}/containers/systemd/gnome_mutter.container
+%{qm_sysconfdir}/containers/systemd/session-activate.container
+%{qm_sysconfdir}/containers/systemd/wayland-extra-devices.conf
+%{qm_sysconfdir}/containers/systemd/weston_terminal.container
 
 %changelog
 * Fri Jul 21 2023 RH Container Bot <rhcontainerbot@fedoraproject.org>


### PR DESCRIPTION
## Summary by Sourcery

Adjust the configuration paths and remove references to qm_rootfs in the windowmanager RPM spec file

Enhancements:
- Replace hardcoded rootfs path with a more flexible sysconfdir configuration
- Update version macro to use dynamic versioning

Chores:
- Refactor RPM spec file to use more standard RPM macro practices