### PR TITLE
subpackages: remove dup entry in windowmanager

### DIFF
--- a/etc/containers/systemd/qm.container.d/qm_dropin_mount_bind_window_manager.conf
+++ b/etc/containers/systemd/qm.container.d/qm_dropin_mount_bind_window_manager.conf
@@ -9,4 +9,3 @@ Mount=type=bind,source=/dev/tty4,target=/dev/tty4
 Mount=type=bind,source=/dev/tty5,target=/dev/tty5
 Mount=type=bind,source=/dev/tty6,target=/dev/tty6
 Mount=type=bind,source=/dev/tty7,target=/dev/tty7
-Mount=type=bind,source=/dev/tty0,target=/dev/tty0


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Clean up redundant configuration entry in systemd container mount configuration