### PR TITLE
Removing myself from `CODEOWNERS`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
 # Default to all maintainers if nothing more specific matches
-* @rhatdan @dougsland @yarboa @sandrobonazzola @nsednev @aesteve-rh @pengshanyu @kleinffm
+* @rhatdan @dougsland @yarboa @nsednev @aesteve-rh @pengshanyu @kleinffm


### PR DESCRIPTION
I'm not really owning any code in this repository.

## Summary by Sourcery

Chores:
- Remove the author's entry from the CODEOWNERS file to reflect their current lack of code ownership in the repository