### PR TITLE
Fix for video subsystem containerfile

### DIFF
--- a/subsystems/video/etc/containers/systemd/rear-camera.container
+++ b/subsystems/video/etc/containers/systemd/rear-camera.container
@@ -12,5 +12,5 @@ WantedBy=multi-user.target
 [Container]
 Image=quay.io/qm-images/multimedia:latest
 Exec=fswebcam -r 1024x768 --jpeg 100 /tmp/screenshot.jpg
-Volume=/tmp:/tmp
+Volume=/var/tmp:/tmp:Z
 AddDevice=-/dev/video0


### PR DESCRIPTION
Current rare-camera.container file make rear-camera service fail on QM with error "fopen: Permission denied". 
This change fixes it.

## Summary by Sourcery

Bug Fixes:
- Resolve permission denied error for rear-camera service in the container configuration