### PR TITLE
Fix sub-package Video manual according to containerfile fix

### DIFF
--- a/docs/devel/experimental/SUBPACKAGES.md
+++ b/docs/devel/experimental/SUBPACKAGES.md
@@ -83,10 +83,9 @@ The video sub-package exposes `/dev/video0` (or many video devices required) to 
 
 ```bash
 make TARGETS=video subpackages
-
+sudo dnf install ./rpmbuild/RPMS/noarch/qm-mount-bind-video-0.6.7-1.fc40.noarch.rpm
 sudo systemctl daemon-reload
 sudo podman restart qm
-sudo dnf install ./rpmbuild/RPMS/noarch/qm_mount_bind_video-0.6.7-1.fc40.noarch.rpm
 ```
 
 This simulates a rear camera when the user shifts into reverse gear.
@@ -99,15 +98,15 @@ host> sudo podman exec -it qm bash
 bash-5.2# systemctl daemon-reload
 bash-5.2# systemctl start rear-camera
 
-# ls -la /tmp/screenshot.jpg
--rw-r--r--. 1 root root 516687 Oct 13 04:05 /tmp/screenshot.jpg
+# ls -la /var/tmp/screenshot.jpg
+-rw-r--r--. 1 root root 516687 Oct 13 04:05 /var/tmp/screenshot.jpg
 bash-5.2#
 ```
 
 ### Copy the screenshot to the host and view it
 
 ```bash
-host> sudo podman cp qm:/tmp/screenshot.jpg .
+host> sudo podman cp qm:/var/tmp/screenshot.jpg .
 ```
 
 Great job! Now imagine all the possibilities this opens up!


### PR DESCRIPTION
Changes in manual according to this PR: https://github.com/containers/qm/pull/795
Also for some reason all of the sub-package names have dashes as delimiters. Only "input" has underscores. Changed the name of Video sub-package in the manual to use dashes, as it is used in actual sub-package naming.

## Summary by Sourcery

Update documentation for the video sub-package with corrected installation commands and file path

Enhancements:
- Standardize sub-package naming convention by using dashes instead of underscores in the package name

Documentation:
- Update SUBPACKAGES.md documentation for the video sub-package, correcting RPM package name and screenshot file location