### PR TITLE
Fix setup script for older installations of Fedora

### DIFF
--- a/setup
+++ b/setup
@@ -147,7 +147,7 @@ install() {
     setupRW "${ROOTFS}" "${RWETCFS}" "${RWVARFS}"
 
     EXTRA_FLAG=""
-    if grep -qi "^ID=fedora" /etc/os-release; then
+    if [ "$ID" == "fedora" ] && [ "$VERSION_ID" -ge 41 ]; then
         EXTRA_FLAG="--use-host-config"
     fi
 


### PR DESCRIPTION
--use-host-config is only applicable to dnf5

## Summary by Sourcery

Bug Fixes:
- Modify setup script to handle configuration options more appropriately for different Fedora versions