### PR TITLE
qm.container: drop sys_boot capability

### DIFF
--- a/qm.container
+++ b/qm.container
@@ -64,7 +64,7 @@ SeccompProfile=/usr/share/qm/seccomp-no-rt.json
 PidsLimit=-1
 
 # Comment DropCapability this will allow FFI Tools to surpass their defaults.
-DropCapability=sys_resource
+DropCapability=sys_boot sys_resource
 
 AddDevice=-/dev/kvm
 AddDevice=-/dev/fuse

--- a/tests/e2e/lib/systemd
+++ b/tests/e2e/lib/systemd
@@ -51,8 +51,8 @@ ${container_target}:/tmp/container-${srv}.container"
                 target_service_file=$(podman exec ${container_target} systemctl show -P  SourcePath qm.service)
 	        # START: remove DropCapability to run nested container
                 # TBD: use drop-in files to update qm.service
-                podman exec -it ${container_target} bash -c "sed -i '/^\s*DropCapability=sys_resource/ d' \"${target_service_file}\""
-	        if_error_exit "unable to remove DropCapability=sys_resource in qm.container"
+                podman exec -it ${container_target} bash -c "sed -i '/^\s*DropCapability=/ d' \"${target_service_file}\""
+	        if_error_exit "unable to remove DropCapability=<caps> in qm.container"
 
                 podman exec -it ${container_target} systemctl daemon-reload
                 if_error_exit "unable to execute daemon-reload"


### PR DESCRIPTION
A better solution would be to rely on namespaces,
but in the meantime, this helps clearing a
safety concern from assessors.

## Summary by Sourcery

Enhancements:
- Reduce container privileges by dropping the sys_boot capability