### PR TITLE
Editing and reorganizing the QM README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 3. [BlueChi](#bluechi)
 4. [RPM building dependencies](#rpm-building-dependencies)
 5. [How OOM score adjustment is used in QM](#how-oom-score-adjustment-is-used-in-qm)
-   - [Priority process of OOM killer in the QM context](#priority-process-of-OOM killer-in-the-qm-context)
+   - [Priority process of OOM killer in the QM context](#priority-process-of-OOM-killer-in-the-qm-context)
 6. [Contributing to the QM project](#contributing-to-the-qm-project)
 7. [Network settings](https://github.com/containers/qm/blob/main/docs/tutorials/NETWORK.md)
 8. [Realtime](#realtime)

--- a/README.md
+++ b/README.md
@@ -1,27 +1,24 @@
 # Topics
 
-1. [QM is a containerized environment for running functional safety Quality Management software](#qm-is-a-containerized-environment-for-running-functional-safety-quality-management-software)
-2. [SELinux policy](#selinux-policy)
-3. [BlueChi](#bluechi)
-4. [RPM building dependencies](#rpm-building-dependencies)
-5. [How OOM score adjustment is used in QM](#how-oom-score-adjustment-is-used-in-qm)
-   - [Priority process of OOM killer in the QM context](#priority-process-of-OOM-killer-in-the-qm-context)
-6. [Contributing to the QM project](#contributing-to-the-qm-project)
-7. [Network settings](https://github.com/containers/qm/blob/main/docs/tutorials/NETWORK.md)
-8. [Realtime](#realtime)
-9. [Talks and videos](#talks-and-videos)
-    - [Paving the Way for Uninterrupted Car Operations - DevConf Boston 2024](https://www.youtube.com/watch?v=jTrLqpw7E6Q)
-    - [Security - Sample Risk Analysis according to ISO26262](https://www.youtube.com/watch?v=jTrLqpw7E6Q&t=1268s)
-    - [ASIL and QM - Simulation and Service Monitoring using bluechi and podman](https://www.youtube.com/watch?v=jTrLqpw7E6Q&t=1680s)
-    - [Containers in a Car - DevConf.CZ 2023](https://www.youtube.com/watch?v=FPxka5uDA_4)
-10. [RPM mirrors](#rpm-mirrors)
-11. [Configuring QM](#configuring-qm)
+- [Topics](#topics)
+  - [QM is a containerized environment for running functional safety Quality Management software](#qm-is-a-containerized-environment-for-running-functional-safety-quality-management-software)
+  - [SELinux policy](#selinux-policy)
+  - [BlueChi](#bluechi)
+  - [RPM building dependencies](#rpm-building-dependencies)
+  - [How OOM score adjustment is used in QM](#how-oom-score-adjustment-is-used-in-qm)
+      - [Priority process of OOM killer in the QM context](#priority-process-of-oom-killer-in-the-qm-context)
+  - [Contributing to the QM project](#contributing-to-the-qm-project)
+  - [Realtime](#realtime)
+  - [Talks and videos](#talks-and-videos)
+  - [RPM mirrors](#rpm-mirrors)
+  - [Configuring QM](#configuring-qm)
+    - [Modifying the `MemoryHigh` variable](#modifying-the-memoryhigh-variable)
 
 ## QM is a containerized environment for running functional safety Quality Management software
 
-The main purpose of the Quality Management (QM) environment is to allow users to configure 
-an environment that prevents applications and container tools from interfering with 
-other processes on the system, such as in Automotive Safety Integrity Level (ASIL) 
+The main purpose of the Quality Management (QM) environment is to allow users to configure
+an environment that prevents applications and container tools from interfering with
+other processes on the system, such as in Automotive Safety Integrity Level (ASIL)
 processes and applications.
 
 The QM environment uses containerization tools, such as cgroups, namespaces, and
@@ -36,7 +33,7 @@ environment and uses Quadlet to set it up. Refer to the [docs directory](docs/qu
 for example Quadlet files.
 
 Software installed in the QM environment under `/usr/lib/qm/rootfs` is
-automatically isolated from the host. To further isolate these processes 
+automatically isolated from the host. To further isolate these processes
 from other processes in the QM, developers can use container tools, such as Podman.
 
 ## SELinux policy
@@ -44,15 +41,15 @@ from other processes in the QM, developers can use container tools, such as Podm
 The SELinux policy isolates QM parts of the operating system
 from the other domain-specific functional safety levels, such as ASIL.
 
-The main purpose of this policy is to prevent applications and container 
-tools from interfering with other processes on the system. The QM must 
+The main purpose of this policy is to prevent applications and container
+tools from interfering with other processes on the system. The QM must
 isolate containers from `qm_t` processes as well as from other containers.
 
 For now, all of the control processes in the QM other than containers run
 with the same `qm_t` type.
 
-For support with a specific SELinux issue, open a [QM issue](https://github.com/containers/qm/issues) 
-and include the SELinux error output from a recent QM-related operation. 
+For support with a specific SELinux issue, open a [QM issue](https://github.com/containers/qm/issues)
+and include the SELinux error output from a recent QM-related operation.
 
 The following commands yield output that can help determine the root cause of the issue:
 
@@ -68,16 +65,16 @@ sealert -a /var/log/audit/audit.log
 
 The package configures the bluechi-agent within the QM.
 
-BlueChi is a systemd service controller intended for use in highly regulated 
-ecosystems that feature multi-node environments with a predefined number of nodes. 
+BlueChi is a systemd service controller intended for use in highly regulated
+ecosystems that feature multi-node environments with a predefined number of nodes.
 Potential use cases can be found in industries that require functional safety,
 such as the transportation industry in which services must be controlled across different
 edge devices and where traditional orchestration tools do not comply with
 regulatory requirements.
 
-Systems with QM installed have two systemd processes running on them. The QM 
-bluechi-agent is based on the hosts `/etc/bluechi/agent.conf` file. By default, any 
-changes to the system's `agent.conf` file are reflected in the QM `/etc/bluechi/agent.conf` file. 
+Systems with QM installed have two systemd processes running on them. The QM
+bluechi-agent is based on the hosts `/etc/bluechi/agent.conf` file. By default, any
+changes to the system's `agent.conf` file are reflected in the QM `/etc/bluechi/agent.conf` file.
 You can further customize the QM bluechi-agent by adding content to the
 `/usr/lib/qm/rootfs/etc/bluechi/agent.conf.d/` directory.
 
@@ -93,12 +90,12 @@ repository for access to the `golang-github-cpuguy83-md2man` package.
 
 ## How OOM score adjustment is used in QM
 
-The `oom_score_adj` parameter refers to the Out-of-Memory score adjustment in Linux operating systems. 
-The Out-of-Memory (OOM) killer uses the `oom_score_adj` parameter to decide which processes to terminate 
+The `oom_score_adj` parameter refers to the Out-of-Memory score adjustment in Linux operating systems.
+The Out-of-Memory (OOM) killer uses the `oom_score_adj` parameter to decide which processes to terminate
 when the system is critically low on memory.
 
-By fine-tuning which processes are more likely to be terminated during low-memory situations, 
-critical processes can be protected, which enhances the overall stability of the system. 
+By fine-tuning which processes are more likely to be terminated during low-memory situations,
+critical processes can be protected, which enhances the overall stability of the system.
 
 - For example, ASIL applications are essential to maintaining functional safety in automotive systems.
 You can set their OOM score adjustment value from *-1* to *-1000*. To prioritize their operation
@@ -205,7 +202,7 @@ SeccompProfile=""
 
 ## Talks and videos
 
-Let's spread the knowledge regarding QM. If you have interesting content pertaining to 
+Let's spread the knowledge regarding QM. If you have interesting content pertaining to
 QM-related technology, please share it with us.
 
 ## RPM mirrors
@@ -214,21 +211,21 @@ Looking for a specific version of QM? Search the [CentOS Automotive SIG Stream M
 
 ## Configuring QM
 
-To run QM on an immutable OSTree-based OS, we use systemd units with Podman Quadlet.  
+To run QM on an immutable OSTree-based OS, we use systemd units with Podman Quadlet.
 For more information on how `podman-systemd.unit` works, refer to the manual:
 
 `man podman-systemd.unit`
 
 The default QM configuration drop-in file is located in `/usr/share/containers/systemd/qm.container`.
-Modifying the original service file is not an option. Instead, create drop-in files to 
+Modifying the original service file is not an option. Instead, create drop-in files to
 modify the default configuration.
 
 **NOTE:** The configuration is built in alphabetical order of the drop-in files.
 
 ### Modifying the `MemoryHigh` variable
 
-To override the default settings, create a new drop-in `.conf` file in the 
-`/etc/containers/systemd/qm.container.d/` directory. This method ensures that QM memory 
+To override the default settings, create a new drop-in `.conf` file in the
+`/etc/containers/systemd/qm.container.d/` directory. This method ensures that QM memory
 usage is controlled without modifying the base system configuration.
 
 **Procedure**
@@ -243,7 +240,7 @@ infinity
 
 ```
 
-The command output `infinity` indicates that `MemoryHigh` is unlimited. You can 
+The command output `infinity` indicates that `MemoryHigh` is unlimited. You can
 see this setting in `/usr/share/containers/systemd/qm.container`.
 
 2. Create a directory for the new drop-in file:

--- a/README.md
+++ b/README.md
@@ -228,8 +228,6 @@ To override the default settings, create a new drop-in `.conf` file in the
 `/etc/containers/systemd/qm.container.d/` directory. This method ensures that QM memory
 usage is controlled without modifying the base system configuration.
 
-*Procedure*
-
 1. Check the current memory limit:
 
 ```bash
@@ -251,12 +249,10 @@ mkdir -p /etc/containers/systemd/qm.container.d/
 
 ```
 
-1.  Create a new drop-in file:
+1. Create a new drop-in file:
 
 ```bash
-
 vim /etc/containers/systemd/qm.container.d/100-MemoryMax.conf
-
 ```
 
 In this example, the new drop-in file is named `100-MemoryMax.conf`. You can choose a different name,

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   - [BlueChi](#bluechi)
   - [RPM building dependencies](#rpm-building-dependencies)
   - [How OOM score adjustment is used in QM](#how-oom-score-adjustment-is-used-in-qm)
-      - [Priority process of OOM killer in the QM context](#priority-process-of-oom-killer-in-the-qm-context)
+    - [Priority process of OOM killer in the QM context](#priority-process-of-oom-killer-in-the-qm-context)
   - [Contributing to the QM project](#contributing-to-the-qm-project)
   - [Realtime](#realtime)
   - [Talks and videos](#talks-and-videos)
@@ -116,7 +116,7 @@ $ cat /usr/share/qm/containers.conf | grep oom_score_adj
 oom_score_adj = 750
 ```
 
-#### Priority process of OOM killer in the QM context
+### Priority process of OOM killer in the QM context
 
 ```txt
 +-------------------------------------------------------------+
@@ -228,7 +228,7 @@ To override the default settings, create a new drop-in `.conf` file in the
 `/etc/containers/systemd/qm.container.d/` directory. This method ensures that QM memory
 usage is controlled without modifying the base system configuration.
 
-**Procedure**
+*Procedure*
 
 1. Check the current memory limit:
 
@@ -243,7 +243,7 @@ infinity
 The command output `infinity` indicates that `MemoryHigh` is unlimited. You can
 see this setting in `/usr/share/containers/systemd/qm.container`.
 
-2. Create a directory for the new drop-in file:
+1. Create a directory for the new drop-in file:
 
 ```bash
 
@@ -251,7 +251,7 @@ mkdir -p /etc/containers/systemd/qm.container.d/
 
 ```
 
-3.  Create a new drop-in file:
+1.  Create a new drop-in file:
 
 ```bash
 
@@ -262,7 +262,7 @@ vim /etc/containers/systemd/qm.container.d/100-MemoryMax.conf
 In this example, the new drop-in file is named `100-MemoryMax.conf`. You can choose a different name,
 but be aware that the configuration is built in alphabetical order of the drop-in files.
 
-4. Edit the file to add the following content:
+1. Edit the file to add the following content:
 
 ```bash
 
@@ -274,7 +274,7 @@ MemoryHigh=2G
 
 `MemoryHigh` is specified in gigabytes. 2G means 2 gigabytes.
 
-5. Preview the updated systemd configuration:
+1. Preview the updated systemd configuration:
 
 ```bash
 
@@ -282,7 +282,7 @@ MemoryHigh=2G
 
 ```
 
-6. Reload systemd and restart `qm.service` to apply the configuration changes:
+1. Reload systemd and restart `qm.service` to apply the configuration changes:
 
 ```bash
 
@@ -292,7 +292,7 @@ systemctl restart qm.service
 
 ```
 
-7. Verify the value of `MemoryHigh`:
+1. Verify the value of `MemoryHigh`:
 
 ```bash
 

--- a/README.md
+++ b/README.md
@@ -1,65 +1,60 @@
 # Topics
 
-1. [QM is a containerized environment for running Functional Safety QM (Quality Management) software](#qm-is-a-containerized-environment-for-running-functional-safety-qm-quality-management-software)
-2. [SELinux Policy](#selinux-policy)
+1. [QM is a containerized environment for running functional safety Quality Management software](#qm-is-a-containerized-environment-for-running-functional-safety-quality-management-software)
+2. [SELinux policy](#selinux-policy)
 3. [BlueChi](#bluechi)
-4. [RPM Building Dependencies](#rpm-building-dependencies)
-5. [How the OOM Score Adjustment is Used in QM](#how-the-oom-score-adjustment-is-used-in-qm)
-    - [Why Use oom score adj in QM?](#why-use-oomscoreadj-in-qm)
-    - [OOM Score Adjustment in QM](#oom-score-adjustment-in-qm)
-    - [Nested Containers](#nested-containers)
-    - [QM Process](#qm-process)
-    - [ASIL Applications](#asil-applications)
-    - [Highlights](#highlights)
-    - [ASCII Diagram](#ascii-diagram)
-6. [Examples](#examples)
-7. [Development](#development)
-8. [Network Settings](https://github.com/containers/qm/blob/main/docs/tutorials/NETWORK.md)
-9. [Realtime](#realtime)
-10. [Talks and Videos](#talks-and-videos)
+4. [RPM building dependencies](#rpm-building-dependencies)
+5. [How OOM score adjustment is used in QM](#how-oom-score-adjustment-is-used-in-qm)
+   - [Priority process of OOM killer in the QM context](#priority-process-of-OOM killer-in-the-qm-context)
+6. [Contributing to the QM project](#contributing-to-the-qm-project)
+7. [Network settings](https://github.com/containers/qm/blob/main/docs/tutorials/NETWORK.md)
+8. [Realtime](#realtime)
+9. [Talks and videos](#talks-and-videos)
     - [Paving the Way for Uninterrupted Car Operations - DevConf Boston 2024](https://www.youtube.com/watch?v=jTrLqpw7E6Q)
     - [Security - Sample Risk Analysis according to ISO26262](https://www.youtube.com/watch?v=jTrLqpw7E6Q&t=1268s)
     - [ASIL and QM - Simulation and Service Monitoring using bluechi and podman](https://www.youtube.com/watch?v=jTrLqpw7E6Q&t=1680s)
     - [Containers in a Car - DevConf.CZ 2023](https://www.youtube.com/watch?v=FPxka5uDA_4)
-11. [RPM Mirrors](#rpm-mirrors)
-12. [Changing QM Configuration](#changing-qm-configuration)
+10. [RPM mirrors](#rpm-mirrors)
+11. [Configuring QM](#configuring-qm)
 
-## QM is a containerized environment for running Functional Safety QM (Quality Management) software
+## QM is a containerized environment for running functional safety Quality Management software
 
-The main purpose of this package is to allow users to set up an environment which
-prevents applications and container tools from interfering with other processes
-on the system. For example ASIL (Automotive Safety Integrity Level) environments.
+The main purpose of the Quality Management (QM) environment is to allow users to configure 
+an environment that prevents applications and container tools from interfering with 
+other processes on the system, such as in Automotive Safety Integrity Level (ASIL) 
+processes and applications.
 
-The QM environment uses containerization tools like cgroups, namespaces, and
-security isolation to prevent accidental interference by processes in the qm.
+The QM environment uses containerization tools, such as cgroups, namespaces, and
+security isolation, to prevent accidental interference by processes in the QM.
 
-The QM will run its own version of systemd and Podman to isolate not only the
-applications and containers launched by systemd and Podman but systemd and
+The QM runs its own version of systemd and Podman to isolate not only the
+applications and containers launched by systemd and Podman, but also systemd and
 Podman commands themselves.
 
 This package requires the Podman package to establish the containerized
-environment and uses quadlet to set it up.
+environment and uses Quadlet to set it up. Refer to the [docs directory](docs/quadlet-examples/)
+for example Quadlet files.
 
-Software install into the qm environment under /usr/lib/qm/rootfs will
-be automatically isolated from the host. But if developers want to further
-isolate these processes from other processes in the QM they can use container
-tools like Podman to further isolate.
+Software installed in the QM environment under `/usr/lib/qm/rootfs` is
+automatically isolated from the host. To further isolate these processes 
+from other processes in the QM, developers can use container tools, such as Podman.
 
-## SELinux Policy
+## SELinux policy
 
-This policy is used to isolate Quality Management parts of the operating system
-from the other Domain-Specific Functional Safety Levels (ASIL).
+The SELinux policy isolates QM parts of the operating system
+from the other domain-specific functional safety levels, such as ASIL.
 
-The main purpose of this policy is to prevent applications and container tools
-with interfering with other processes on the system. The QM needs to support
-further isolate containers run within the qm from the qm_t process and from
-each other.
+The main purpose of this policy is to prevent applications and container 
+tools from interfering with other processes on the system. The QM must 
+isolate containers from `qm_t` processes as well as from other containers.
 
-For now all of the control processes in the qm other then containers will run
-with the same qm_t type.
+For now, all of the control processes in the QM other than containers run
+with the same `qm_t` type.
 
-Still would like to discuss about a specific selinux prevision?
-Please open an [QM issue](https://github.com/containers/qm/issues) with the output of selinux error from a recent operation related to QM. The output of the following commands are appreciated for understanding the root cause.
+For support with a specific SELinux issue, open a [QM issue](https://github.com/containers/qm/issues) 
+and include the SELinux error output from a recent QM-related operation. 
+
+The following commands yield output that can help determine the root cause of the issue:
 
 ```console
 ausearch -m avc -ts recent | audit2why
@@ -67,24 +62,24 @@ journalctl -t setroubleshoot
 sealert -a /var/log/audit/audit.log
 ```
 
-## Bluechi
+## BlueChi
 
 - [BlueChi](https://github.com/containers/qm/pull/57)
 
-The package configures the bluechi agent within the QM.
+The package configures the bluechi-agent within the QM.
 
-BlueChi is a systemd service controller intended for multi-node environments with
-a predefined number of nodes and with a focus on highly regulated ecosystems such
-as those requiring functional safety. Potential use cases can be found in domains
-such as transportation, where services need to be controlled across different
-edge devices and where traditional orchestration tools are not compliant with
+BlueChi is a systemd service controller intended for use in highly regulated 
+ecosystems that feature multi-node environments with a predefined number of nodes. 
+Potential use cases can be found in industries that require functional safety,
+such as the transportation industry in which services must be controlled across different
+edge devices and where traditional orchestration tools do not comply with
 regulatory requirements.
 
-Systems with QM installed will have two systemd's running on them. The QM bluechi-agent
-is based on the hosts /etc/bluechi/agent.conf file. By default any changes to the
-systems agent.conf file are reflected into the QM /etc/bluechi/agent.conf. You can
-further customize the QM bluechi agent by adding content to the
-/usr/lib/qm/rootfs/etc/bluechi/agent.conf.d/ directory.
+Systems with QM installed have two systemd processes running on them. The QM 
+bluechi-agent is based on the hosts `/etc/bluechi/agent.conf` file. By default, any 
+changes to the system's `agent.conf` file are reflected in the QM `/etc/bluechi/agent.conf` file. 
+You can further customize the QM bluechi-agent by adding content to the
+`/usr/lib/qm/rootfs/etc/bluechi/agent.conf.d/` directory.
 
 ```console
 # dnf install -y python3-dnf-plugins-core
@@ -93,48 +88,38 @@ further customize the QM bluechi agent by adding content to the
 
 ## RPM building dependencies
 
-In order to build qm package on CentOS Stream 9 you'll need Code Ready Builder
-repository enabled in order to provide `golang-github-cpuguy83-md2man` package.
+To build QM packages on CentOS Stream 9, enable the Code Ready Builder
+repository for access to the `golang-github-cpuguy83-md2man` package.
 
-## How the OOM Score Adjustment is used in QM
+## How OOM score adjustment is used in QM
 
-The om_score_adj refers to the "Out of Memory score adjustment" in Linux operating systems. This parameter is used by the Out of Memory (OOM) killer to decide which processes to terminate when the system is critically low on memory.
+The `oom_score_adj` parameter refers to the Out-of-Memory score adjustment in Linux operating systems. 
+The Out-of-Memory (OOM) killer uses the `oom_score_adj` parameter to decide which processes to terminate 
+when the system is critically low on memory.
 
-### Why use oomscoreadj in QM?
+By fine-tuning which processes are more likely to be terminated during low-memory situations, 
+critical processes can be protected, which enhances the overall stability of the system. 
 
-By fine-tuning which processes are more likely to be terminated during low memory situations, critical processes can be protected, thereby enhancing the overall stability of the system. For instance only, ASIL (Automotive Safety Integrity Level) applications, which are critical for ensuring functional safety in automotive systems, will be preserved in case of low resources.
+- For example, ASIL applications are essential to maintaining functional safety in automotive systems.
+You can set their OOM score adjustment value from *-1* to *-1000*. To prioritize their operation
+even in low-memory situations, setting the value to *-1000* makes the process immune to the OOM killer
+and ensures that ASIL applications are the last to be terminated.
 
-### OOM Score Adjustment in QM
-
-#### Nested Containers
-
-- All nested containers created inside QM will have their OOM score adjustment set to *750*.
-
-```console
-$ cat /usr/share/qm/containers.conf | grep oom_score_adj
-oom_score_adj = 750
-```
-
-#### QM Process
-
-- The QM process has a default OOM score adjustment value set to *500*, configured via the *qm.container* file.
+- The QM process has a default OOM score adjustment value set to *500*, configured via the `qm.container` file.
 
 ```console
 cat /usr/share/containers/systemd/qm.container | grep OOMScoreAdjust
 # OOMScoreAdjust=500
 ```
 
-### ASIL Applications
+- All nested containers created inside the QM have a default OOM score adjustment of *750*.
 
-If we consider the example of ASIL (Automotive Safety Integrity Level) applications, which are essential for maintaining functional safety in automotive systems, their OOM score adjustment values can range from -1 to -1000. Setting the value to -1000 makes the process immune to the OOM killer. This ensures that ASIL applications are the last to be terminated by the OOM killer, thus prioritizing their operation even in low memory situations.
+```console
+$ cat /usr/share/qm/containers.conf | grep oom_score_adj
+oom_score_adj = 750
+```
 
-#### Highlights
-
-- Nested Containers inside QM: OOM score adjustment set to 750. (/usr/share/qm/containers.conf)
-- QM Process: OOM score adjustment value set to 500, configured via the qm.container file.
-- ASIL Applications: Can explore a range from -1 to -1000, with -1000 making the process immune to the OOM killer.
-
-#### ASCII Diagram
+#### Priority process of OOM killer in the QM context
 
 ```txt
 +-------------------------------------------------------------+
@@ -193,7 +178,7 @@ If we consider the example of ASIL (Automotive Safety Integrity Level) applicati
          |                                                             |
          | Compared to other processes with the default adjustment     |
          | value of 0, nested containers are still more likely to be   |
-         | terminated first, ensuring the system and ASIL Apps are     |
+         | terminated first, ensuring the system and ASIL apps are     |
          | kept as safe as possible.                                   |
          |                                                             |
          +-------------------------------------------------------------+
@@ -203,17 +188,13 @@ If we consider the example of ASIL (Automotive Safety Integrity Level) applicati
 ------------------------------------ Kernel space -----------------------------------------------
 ```
 
-## Examples
+## Contributing to the QM project
 
-Looking for quadlet examples files? See our [docs dir](docs/quadlet-examples/).
-
-## Development
-
-If you're looking to contribute to the project, use our [development README guide](docs/devel/README.md) to help you get started.
+For information about how to contribute to the QM project, see the [Developers documentation README](docs/devel/README.md).
 
 ## Realtime
 
-To enable real-time removal of sched_* blockage via seccomp, use the following schema.
+To enable real-time removal of sched_* blockage via seccomp, use the following schema:
 
 ```bash
 cat << EOF >> /etc/containers/systemd/qm.container.d/rt.conf
@@ -222,69 +203,69 @@ SeccompProfile=""
 > EOF
 ```
 
-## Talks and Videos
+## Talks and videos
 
-Let's spread the knowledge regarding QM, if you have any interesting video regarding any
-technology related to QM please with us.
+Let's spread the knowledge regarding QM. If you have interesting content pertaining to 
+QM-related technology, please share it with us.
 
-## RPM Mirrors
+## RPM mirrors
 
-Looking for a specific version of QM?
-Search in the mirrors list below.
+Looking for a specific version of QM? Search the [CentOS Automotive SIG Stream Mirror](https://mirror.stream.centos.org/SIGs/9-stream/automotive/aarch64/packages-main/Packages/q/).
 
-[CentOS Automotive SIG - qm package - noarch](https://mirror.stream.centos.org/SIGs/9-stream/automotive/aarch64/packages-main/Packages/q/)
+## Configuring QM
 
-## Changing QM Configuration
-
-### Overview
-
-To run QM on an immutable OSTree-based OS, we utilize systemd units with Podman Quadlet. Since modifying the original service file is not an option, we must use drop-in files to adjust the default configuration.
-
-For more information on how podman-systemd.unit works, refer to the manual by running:
+To run QM on an immutable OSTree-based OS, we use systemd units with Podman Quadlet.  
+For more information on how `podman-systemd.unit` works, refer to the manual:
 
 `man podman-systemd.unit`
 
-### Default Configuration File
+The default QM configuration drop-in file is located in `/usr/share/containers/systemd/qm.container`.
+Modifying the original service file is not an option. Instead, create drop-in files to 
+modify the default configuration.
 
-The default QM configuration drop-in file is located at:
+**NOTE:** The configuration is built in alphabetical order of the drop-in files.
 
- /usr/share/containers/systemd/qm.container
+### Modifying the `MemoryHigh` variable
 
-To override settings, create new drop-in files (ending in .conf) under the following directory `/etc/containers/systemd/qm.container.d/`. If the directory does not exist, create it first:
+To override the default settings, create a new drop-in `.conf` file in the 
+`/etc/containers/systemd/qm.container.d/` directory. This method ensures that QM memory 
+usage is controlled without modifying the base system configuration.
 
- `mkdir -p /etc/containers/systemd/qm.container.d/`
+**Procedure**
 
-### Modifying the MemoryHigh Variable Example
+1. Check the current memory limit:
 
-#### Checking the Current Memory Limit
+```bash
 
-Please run:
+systemctl show -P MemoryHigh qm
 
-`systemctl show -P MemoryHigh qm`
+infinity
 
-Expected output:
+```
 
-`infinity`
+The command output `infinity` indicates that `MemoryHigh` is unlimited. You can 
+see this setting in `/usr/share/containers/systemd/qm.container`.
 
-This indicates that MemoryHigh is currently unlimited and can be viewed in `/usr/share/containers/systemd/qm.container`.
-
-#### Setting a Memory Limit of 2G
-
-To impose a memory usage limit of 2G for QM:
-
-Create a Drop-in Configuration File and the directory
+2. Create a directory for the new drop-in file:
 
 ```bash
 
 mkdir -p /etc/containers/systemd/qm.container.d/
 
+```
+
+3.  Create a new drop-in file:
+
+```bash
+
 vim /etc/containers/systemd/qm.container.d/100-MemoryMax.conf
 
 ```
 
-The name that was choosen for the new drop-in file is  `100-MemoryMax.conf` this name can be changed but please keep in mind that the configuration will be build by alphabetic order of the drop-in files.
+In this example, the new drop-in file is named `100-MemoryMax.conf`. You can choose a different name,
+but be aware that the configuration is built in alphabetical order of the drop-in files.
 
-Edit the File and Add the Following Content:
+4. Edit the file to add the following content:
 
 ```bash
 
@@ -294,17 +275,17 @@ MemoryHigh=2G
 
 ```
 
-(MemoryHigh is specified in gigabytes; e.g., 2G means 2 gigabytes.)
+`MemoryHigh` is specified in gigabytes. 2G means 2 gigabytes.
 
-#### Verifying the New Configuration
+5. Preview the updated systemd configuration:
 
-To preview the updated systemd configuration, run:
+```bash
 
-`/usr/lib/systemd/system-generators/podman-system-generator {--user} --dryrun`
+/usr/lib/systemd/system-generators/podman-system-generator {--user} --dryrun
 
-#### Applying service configuration changes
+```
 
-Reload systemd and restart QM with the following commands:
+6. Reload systemd and restart `qm.service` to apply the configuration changes:
 
 ```bash
 
@@ -314,18 +295,13 @@ systemctl restart qm.service
 
 ```
 
-This confirms that MemoryHigh is now set to 2G.
+7. Verify the value of `MemoryHigh`:
 
-#### Final Confirmation
+```bash
 
-To ensure the 2G limit is enforced, check the value of `MemoryHigh` with the same command that mentioned above:
+systemctl show -P MemoryHigh qm
 
-`systemctl show -P MemoryHigh qm`
+2147483648
+```
 
-Expected output:
-
-`2147483648`
-
-(Memory values are displayed in bytes; 2147483648 bytes = 2G.)
-
-This method ensures that QM's memory usage is controlled without modifying the base system configuration.
+Memory values are displayed in bytes; 2147483648 bytes = 2G, which confirms that `MemoryHigh` is set to 2G.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 - [Topics](#topics)
   - [QM is a containerized environment for running functional safety Quality Management software](#qm-is-a-containerized-environment-for-running-functional-safety-quality-management-software)
-  - [SELinux policy](#selinux-policy)
+  - [QM SELinux policy](#qm-selinux-policy)
   - [BlueChi](#bluechi)
   - [RPM building dependencies](#rpm-building-dependencies)
   - [How OOM score adjustment is used in QM](#how-oom-score-adjustment-is-used-in-qm)
@@ -19,7 +19,8 @@
 The main purpose of the Quality Management (QM) environment is to allow users to configure
 an environment that prevents applications and container tools from interfering with
 other processes on the system, such as in Automotive Safety Integrity Level (ASIL)
-processes and applications.
+processes and applications. AutoSD is not a certified safety product. In the context of
+AutoSD, QM is not for use in production environments but for research and learning purposes only.
 
 The QM environment uses containerization tools, such as cgroups, namespaces, and
 security isolation, to prevent accidental interference by processes in the QM.
@@ -36,9 +37,9 @@ Software installed in the QM environment under `/usr/lib/qm/rootfs` is
 automatically isolated from the host. To further isolate these processes
 from other processes in the QM, developers can use container tools, such as Podman.
 
-## SELinux policy
+## QM SELinux policy
 
-The SELinux policy isolates QM parts of the operating system
+The QM SELinux policy isolates QM parts of the operating system
 from the other domain-specific functional safety levels, such as ASIL.
 
 The main purpose of this policy is to prevent applications and container
@@ -46,7 +47,7 @@ tools from interfering with other processes on the system. The QM must
 isolate containers from `qm_t` processes as well as from other containers.
 
 For now, all of the control processes in the QM other than containers run
-with the same `qm_t` type.
+with the same `qm_t` type. For more information, refer to `man qm_selinx`.
 
 For support with a specific SELinux issue, open a [QM issue](https://github.com/containers/qm/issues)
 and include the SELinux error output from a recent QM-related operation.
@@ -90,9 +91,11 @@ repository for access to the `golang-github-cpuguy83-md2man` package.
 
 ## How OOM score adjustment is used in QM
 
+The Linux host kernel controls ASIL and QM processes. The Out-of-Memory (OOM) Killer is part of the Linux
+kernel's memory management subsystem. OOM Killer terminates processes to release RAM in memory-constrained conditions.
 The `oom_score_adj` parameter refers to the Out-of-Memory score adjustment in Linux operating systems.
-The Out-of-Memory (OOM) killer uses the `oom_score_adj` parameter to decide which processes to terminate
-when the system is critically low on memory.
+The OOM Killer uses the `oom_score_adj` parameter to decide which processes to terminate when the system is
+critically low on memory.
 
 By fine-tuning which processes are more likely to be terminated during low-memory situations,
 critical processes can be protected, which enhances the overall stability of the system.
@@ -207,7 +210,7 @@ QM-related technology, please share it with us.
 
 ## RPM mirrors
 
-Looking for a specific version of QM? Search the [CentOS Automotive SIG Stream Mirror](https://mirror.stream.centos.org/SIGs/9-stream/automotive/aarch64/packages-main/Packages/q/).
+Looking for a specific version of QM? Search the [CentOS Automotive SIG Stream Mirror](https://mirror.stream.centos.org/SIGs/9-stream/automotive/aarch64/packages-main/Packages/q/). The packages in CentOS Automotive SIG Stream Mirror are for experimentation only.
 
 ## Configuring QM
 

--- a/docs/devel/README.md
+++ b/docs/devel/README.md
@@ -18,8 +18,6 @@
   - [SSH guest CentOS Automotive Stream Distro](#ssh-guest-centos-automotive-stream-distro)
   - [Check if HOST and Container are using different network namespace](#check-if-host-and-container-are-using-different-network-namespace)
   - [Debugging with podman in QM using --root](#debugging-with-podman-in-qm)
-  - [Creating your own drop-in QM sub-package](#creating-your-own-dropin-qm-subpackage)
-  - [Install PR copr subpackages on local machine](#install-pr-copr-subpackages-on-local-machine)
   - [Debugging with quadlet](#debugging-with-quadlet)
 
 ## Building QM rpm manually with changes
@@ -395,47 +393,6 @@ lrwxrwxrwx. 1 root root 0 May  1 04:33 /proc/self/ns/net -> 'net:[4026532287]'
 bash-5.1# podman --root /usr/share/containers/storage pull alpine
 Error: creating runtime static files directory "/usr/share/containers/storage/libpod":
 mkdir /usr/share/containers/storage: read-only file system
-```
-
-### Creating your own dropin QM subpackage
-
-We recommend using the existing drop-in files as a guide and adapting them to your specific needs. However, here are the step-by-step instructions:
-
-1) Create a drop-in file in the directory: `etc/qm/containers/containers.conf.d/`
-2) Add it as a sub-package to `rpm/<subpackage>.spec`
-3) Test it by running: `make clean && make TARGETS=<subpackage> subpackages`
-4) Additionally, test it with and without enabling the sub-package using (by default it should be disabled but there are cases where it will be enabled by default if QM community decide):
-
-Example changing the spec and triggering the build via make (feel free to automate via sed, awk etc):
-
-```bash
-# Use make file to run specific subpackage
-make TARGETS=windowmanager subpackages
-
-```
-
-Check rpms created in PT Actions under PR Checks > Packit-as-a-Service
-In case new tests need the sub-package, it will be installed immediatly
-on Packit-as-a-Service test phase.
-
-### Install PR copr subpackages on local machine
-
-1. Enable repo in your machine
-This part is done automatically by TestingFarm guest provisioning.
-In case of manual installation,
-
-```bash
-dnf copr enable packit/containers-qm-<PR_ID> <distro><arch>
-```
-
-1. Install rpm in qm
-This part is done automatically by TestingFarm guest provisioning.
-In case of manual installation,
-
-```bash
-podman cp /etc/yum.repos.d/_copr:copr.fedorainfracloud.org:packit:containers-qm-<PR_ID>.repo qm:/etc/yum.repos.d/
-
-dnf  install --releasever=<VERSION_ID> --installroot /usr/lib/qm/rootfs/ <package>
 ```
 
 ### Debugging with quadlet

--- a/docs/devel/experimental/SUBPACKAGES.md
+++ b/docs/devel/experimental/SUBPACKAGES.md
@@ -8,6 +8,7 @@
     - [Creating Your Own Drop-In QM Sub-Package](#creating-your-own-drop-in-qm-sub-package)
     - [QM Sub-Package Input](#qm-sub-package-input)
     - [QM Sub-Package tty7](#qm-sub-package-tty7)
+    - [QM Sub-Package ttyUSB0](#qm-sub-package-ttyusb0)
     - [QM Sub-Package Video](#qm-sub-package-video)
     - [QM Sub-Package Sound](#qm-sub-package-sound)
     - [QM Sub-Package ROS2](#qm-sub-package-ros2)
@@ -159,6 +160,48 @@ host> sudo podman restart qm
 host> sudo podman exec -it qm ls -l /dev/tty7
 crw--w----. 1 root tty 4, 7 Apr 15 13:34 /dev/tty7
 ```
+
+## QM sub-package ttyUSB0
+
+The ttyUSB0 sub-package exposes /dev/ttyUSB0 to the QM container. This device node is commonly used for USB-to-serial adapters, which are widely used to connect embedded systems, IoT devices, or other serial-based equipment.
+
+### Step 1: Verify ttyUSB0 is NOT visible inside QM
+
+```bash
+host> sudo podman exec -it qm ls -l /dev/ttyUSB0
+ls: cannot access '/dev/ttyUSB0': No such file or directory
+```
+
+### Step 2: Build and install the ttyUSB0 sub-package
+
+```bash
+host> make TARGETS=ttyUSB0 subpackages
+host> sudo dnf install ./rpmbuild/RPMS/noarch/qm-mount-bind-ttyUSB0-0.7.4-1.fc41.noarch.rpm
+```
+
+### Step 3: Restart QM to apply the configuration
+
+```bash
+host> sudo systemctl daemon-reload
+host> sudo podman restart qm
+```
+
+### Step 4: Re-check ttyUSB0 inside QM
+
+```bash
+host> sudo podman exec -it qm ls -l /dev/ttyUSB0
+crw-rw-rw-. 1 root root 4, 64 Apr 24 08:50 /dev/ttyUSB0
+```
+
+### Additional Notes
+
+- Make sure the USB-to-serial device is connected to the host machine before restarting QM.
+- You can fake ttyUSB0 connection on host machine for testing reasons with:
+
+    ```bash
+    sudo mknod /dev/ttyUSB0 c 4 64
+    sudo chmod 666 /dev/ttyUSB0
+    ```
 
 ## QM sub-package Video
 

--- a/docs/devel/experimental/SUBPACKAGES.md
+++ b/docs/devel/experimental/SUBPACKAGES.md
@@ -82,7 +82,20 @@ sudo rpm -e qm_mount_bind_input
 
 We recommend using the existing drop-in files as a guide and adapting them to your specific needs. However, here are the step-by-step instructions:
 
-Please refer [Creating your own drop-in QM sub-package](/docs/devel/README.md#creating-your-own-dropin-qm-subpackage)
+1) Add a drop-in file to: `etc/containers/systemd/qm.container.d/qm_dropin_<subpackage>.conf>`
+2) Add your package as a sub-package to: `rpm/<subpackage_directory>/<subpackage>.spec`
+3) Add the makefile for the sub-package and any files required by the sub-package to: `subsystems/<subpackage_directory>`
+4) Test the sub-package build by running: `make clean && make TARGETS=<subpackage> subpackages`
+5) Install your sub-package using: `dnf install -y rpmbuild/RPMS/noarch/<subpackage>*.noarch.rpm`
+6) Restart podman container using: `sudo podman restart qm`
+7) Additionally, test it with and without enabling the sub-package using (by default it should be disabled but there are cases where it will be enabled by default if QM community decide):
+
+Example changing the spec and triggering the build via make (feel free to automate via sed, awk etc):
+
+```bash
+# Use make file to run specific subpackage
+make TARGETS=windowmanager subpackages
+```
 
 ## QM sub-package Input
 

--- a/rpm/dvb/dvb.spec
+++ b/rpm/dvb/dvb.spec
@@ -22,7 +22,7 @@ This subpackage installs a drop-in configuration for QM containers to mount bind
 install -d %{buildroot}%{_sysconfdir}/containers/systemd/qm.container.d
 
 # Install the dvb drop-in configuration file
-install -m 644 %{_builddir}/qm-video-%{version}/etc/containers/systemd/qm.container.d/qm_dropin_mount_bind_dvb.conf \
+install -m 644 %{_builddir}/qm-dvb-%{version}/etc/containers/systemd/qm.container.d/qm_dropin_mount_bind_dvb.conf \
     %{buildroot}%{_sysconfdir}/containers/systemd/qm.container.d/qm_dropin_mount_bind_dvb.conf
 
 

--- a/rpm/input/input.spec
+++ b/rpm/input/input.spec
@@ -1,6 +1,6 @@
 %global debug_package %{nil}
 
-Name: qm_mount_bind_input
+Name: qm-mount-bind-input
 Version: 0
 Release: 1%{?dist}
 Summary: Drop-in configuration for QM containers to mount bind input devices

--- a/rpm/ttyUSB0/ttyUSB0.spec
+++ b/rpm/ttyUSB0/ttyUSB0.spec
@@ -1,6 +1,6 @@
 %global debug_package %{nil}
 
-Name: qm_mount_bind_ttyUSB0
+Name: qm-mount-bind-ttyUSB0
 Version: 0
 Release: 1%{?dist}
 Summary: Drop-in configuration for QM containers to mount bind ttyUSB0

--- a/subsystems/dvb/Makefile
+++ b/subsystems/dvb/Makefile
@@ -1,7 +1,7 @@
 RPM_TOPDIR ?= $(PWD)/rpmbuild
 VERSION ?= $(shell cat VERSION)
 ROOTDIR ?= $(PWD)
-SPECFILE_SUBPACKAGE_VIDEO ?= ${ROOTDIR}/rpm/dvb/dvb.spec
+SPECFILE_SUBPACKAGE_DVB ?= ${ROOTDIR}/rpm/dvb/dvb.spec
 
 .PHONY: dist
 dist: ##             - Creates the QM dvb package

--- a/subsystems/radio/Makefile
+++ b/subsystems/radio/Makefile
@@ -1,7 +1,7 @@
 RPM_TOPDIR ?= $(PWD)/rpmbuild
 VERSION ?= $(shell cat VERSION)
 ROOTDIR ?= $(PWD)
-SPECFILE_SUBPACKAGE_VIDEO ?= ${ROOTDIR}/rpm/radio/radio.spec
+SPECFILE_SUBPACKAGE_RADIO ?= ${ROOTDIR}/rpm/radio/radio.spec
 
 .PHONY: dist
 dist: ##             - Creates the QM radio package
@@ -12,7 +12,7 @@ dist: ##             - Creates the QM radio package
 		../qm/README.md \
 		../qm/SECURITY.md \
 		../qm/LICENSE \
-                ../qm/etc/containers/systemd/qm.container.d/qm_dropin_mount_bind_radio.conf
+        ../qm/etc/containers/systemd/qm.container.d/qm_dropin_mount_bind_radio.conf
 	cd $(ROOTDIR) && mv /tmp/qm-radio-${VERSION}.tar.gz ./rpm
 
 

--- a/tests/aib/check_qm_with_aib.sh
+++ b/tests/aib/check_qm_with_aib.sh
@@ -9,6 +9,6 @@ COPR_URL="https://download.copr.fedorainfracloud.org/results/${USE_QM_COPR}/epel
 EXTRA_REPOS='extra_repos=[{"id":"qm_build","baseurl":"'"$COPR_URL"'"}]'
 
 # Run AIB in container
-curl -o auto-image-builder.sh "https://gitlab.com/CentOS/automotive/sample-images/-/raw/main/auto-image-builder.sh?ref_type=heads"
+curl -o auto-image-builder.sh "https://gitlab.com/CentOS/automotive/src/automotive-image-builder/-/raw/main/auto-image-builder.sh?ref_type=heads"
 #shellcheck disable=SC2027,SC2090,SC2086
 /bin/bash auto-image-builder.sh build --export qcow2 --define "'"$EXTRA_REPOS"'" qm.aib.yml qm.qcow2

--- a/tools/qmctl/README.md
+++ b/tools/qmctl/README.md
@@ -30,6 +30,13 @@ Run a command inside a nested container in QM
 ./qmctl execin alpine ls /dev --json
 ```
 
+Copy files to and from QM
+
+```bash
+./qmctl cp README.md qm:/tmp
+./qmctl cp qm:/tmp/README.md ./
+```
+
 With verbose output
 
 ```bash

--- a/tools/qmctl/qmctl
+++ b/tools/qmctl/qmctl
@@ -133,6 +133,46 @@ class QMCTL:
             self._print_output({"error": str(e)}, output_json, pretty)
             sys.exit(1)
 
+    def copy_in_container(self, paths, output_json=False, pretty=True):
+        if not self._container_exists(self.container):
+            self._print_output(
+                {"error": f"Container '{self.container}' does not exist."},
+                output_json,
+                pretty
+            )
+            sys.exit(1)
+        if not paths or len(paths) != 2:
+            self._print_output(
+                {"error": "Please provide source and destination paths."},
+                output_json,
+                pretty
+            )
+            sys.exit(1)
+        src = paths[0]
+        dst = paths[1]
+        if not (self.container + ":" in src) ^ (self.container + ":" in dst):
+            self._print_output(
+                {"error": f"Please provide `{self.container}:` only in source or in destination"},
+                output_json,
+                pretty
+            )
+            sys.exit(1)
+
+        try:
+            result = subprocess.run(
+                ["podman", "cp", src, dst] ,
+                capture_output=True,
+                text=True,
+                check=False
+            )
+
+            if result.stderr.lower():
+                raise RuntimeError(result.stderr)
+
+        except Exception as e:
+            self._print_output({"error": str(e)}, output_json, pretty)
+            sys.exit(1)
+
     def execin_in_container(self, command, output_json=False, pretty=True):
         if not self._container_exists(self.container):
             self._print_output(
@@ -318,15 +358,17 @@ def main():
         description="QMCTL: Manage QM container settings via Podman.",
         epilog="""
 Examples:
-  ./qmctl show                              Show raw container config
-  ./qmctl show resources                    Show live systemd-cgtop for qm.service
-  ./qmctl show unix-domain-sockets          Show UNIX sockets inside container
-  ./qmctl show shared-memory                Show shared memory (ipcs)
-  ./qmctl show namespaces                   Show namespaces from container
-  ./qmctl show available-devices            Show devices from container config
-  ./qmctl show all                          Show all options + cgtop snapshot
-  ./qmctl exec uname -a                     Run 'uname -a' in container
-  ./qmctl execin alpine ls /dev             Run 'ls /dev' in alpine a nested container inside QM
+  ./qmctl show                               Show raw container config
+  ./qmctl show resources                     Show live systemd-cgtop for qm.service
+  ./qmctl show unix-domain-sockets           Show UNIX sockets inside container
+  ./qmctl show shared-memory                 Show shared memory (ipcs)
+  ./qmctl show namespaces                    Show namespaces from container
+  ./qmctl show available-devices             Show devices from container config
+  ./qmctl show all                           Show all options + cgtop snapshot
+  ./qmctl exec uname -a                      Run 'uname -a' in container
+  ./qmctl execin alpine ls /dev              Run 'ls /dev' in alpine a nested container inside QM
+  ./qmctl cp /path/to/file QM:/path/to/dir   Copy file from a path to QM
+  ./qmctl cp QM:/path/to/file /path/to/dir   Copy file from QM to dir
 """,
         formatter_class=argparse.RawTextHelpFormatter
     )
@@ -361,6 +403,10 @@ Examples:
     execin_parser.add_argument("cmd", nargs=argparse.REMAINDER, help="Command and continer name to execute")
     execin_parser.add_argument("--json", action="store_true", help="Output as JSON")
 
+    cp_parser = subparsers.add_parser("cp", help="Copy files from and to QM")
+    cp_parser.add_argument("paths", nargs=argparse.REMAINDER, help="source and destination to copy")
+    cp_parser.add_argument("--json", action="store_true", help="Output as JSON")
+
     if argcomplete:
         argcomplete.autocomplete(parser)
 
@@ -390,6 +436,8 @@ Examples:
         qmctl.exec_in_container(command=args.cmd, output_json=args.json, pretty=True)
     elif args.command == "execin":
         qmctl.execin_in_container(command=args.cmd, output_json=args.json, pretty=True)
+    elif args.command == "cp":
+        qmctl.copy_in_container(paths=args.paths, output_json=args.json, pretty=True)
     else:
         parser.print_help()
         sys.exit(1)


### PR DESCRIPTION
I edited and reorganized the README for clarity.  I also noticed that the OOM score adjustment parameter was sometimes `om_score_adj`, where it should have been `oom_score_adj`. I fixed this.

## Summary by Sourcery

Reorganize and improve the QM README for clarity, consistency, and better readability

Enhancements:
- Fixed inconsistent usage of 'om_score_adj' to the correct 'oom_score_adj' term
- Improved section headings and content flow
- Refined technical explanations to be more precise

Documentation:
- Restructured the README with improved section organization and formatting
- Corrected terminology and capitalization throughout the document
- Simplified and clarified explanations of QM concepts and configurations