### PR TITLE
a-i-b.sh moved from sample-images to a-i-b

### DIFF
--- a/tests/aib/check_qm_with_aib.sh
+++ b/tests/aib/check_qm_with_aib.sh
@@ -9,6 +9,6 @@ COPR_URL="https://download.copr.fedorainfracloud.org/results/${USE_QM_COPR}/epel
 EXTRA_REPOS='extra_repos=[{"id":"qm_build","baseurl":"'"$COPR_URL"'"}]'
 
 # Run AIB in container
-curl -o auto-image-builder.sh "https://gitlab.com/CentOS/automotive/sample-images/-/raw/main/auto-image-builder.sh?ref_type=heads"
+curl -o auto-image-builder.sh "https://gitlab.com/CentOS/automotive/src/automotive-image-builder/-/raw/main/auto-image-builder.sh?ref_type=heads"
 #shellcheck disable=SC2027,SC2090,SC2086
 /bin/bash auto-image-builder.sh build --export qcow2 --define "'"$EXTRA_REPOS"'" qm.aib.yml qm.qcow2


### PR DESCRIPTION
update where to get the script from

## Summary by Sourcery

Tests:
- Update `check_qm_with_aib.sh` to fetch `auto-image-builder.sh` from the `automotive-image-builder` repository.