### PR TITLE
Fixes for broken subpackages

### DIFF
--- a/rpm/dvb/dvb.spec
+++ b/rpm/dvb/dvb.spec
@@ -22,7 +22,7 @@ This subpackage installs a drop-in configuration for QM containers to mount bind
 install -d %{buildroot}%{_sysconfdir}/containers/systemd/qm.container.d
 
 # Install the dvb drop-in configuration file
-install -m 644 %{_builddir}/qm-video-%{version}/etc/containers/systemd/qm.container.d/qm_dropin_mount_bind_dvb.conf \
+install -m 644 %{_builddir}/qm-dvb-%{version}/etc/containers/systemd/qm.container.d/qm_dropin_mount_bind_dvb.conf \
     %{buildroot}%{_sysconfdir}/containers/systemd/qm.container.d/qm_dropin_mount_bind_dvb.conf
 
 

--- a/rpm/input/input.spec
+++ b/rpm/input/input.spec
@@ -1,6 +1,6 @@
 %global debug_package %{nil}
 
-Name: qm_mount_bind_input
+Name: qm-mount-bind-input
 Version: 0
 Release: 1%{?dist}
 Summary: Drop-in configuration for QM containers to mount bind input devices

--- a/rpm/ttyUSB0/ttyUSB0.spec
+++ b/rpm/ttyUSB0/ttyUSB0.spec
@@ -1,6 +1,6 @@
 %global debug_package %{nil}
 
-Name: qm_mount_bind_ttyUSB0
+Name: qm-mount-bind-ttyUSB0
 Version: 0
 Release: 1%{?dist}
 Summary: Drop-in configuration for QM containers to mount bind ttyUSB0

--- a/subsystems/dvb/Makefile
+++ b/subsystems/dvb/Makefile
@@ -1,7 +1,7 @@
 RPM_TOPDIR ?= $(PWD)/rpmbuild
 VERSION ?= $(shell cat VERSION)
 ROOTDIR ?= $(PWD)
-SPECFILE_SUBPACKAGE_VIDEO ?= ${ROOTDIR}/rpm/dvb/dvb.spec
+SPECFILE_SUBPACKAGE_DVB ?= ${ROOTDIR}/rpm/dvb/dvb.spec
 
 .PHONY: dist
 dist: ##             - Creates the QM dvb package

--- a/subsystems/radio/Makefile
+++ b/subsystems/radio/Makefile
@@ -1,7 +1,7 @@
 RPM_TOPDIR ?= $(PWD)/rpmbuild
 VERSION ?= $(shell cat VERSION)
 ROOTDIR ?= $(PWD)
-SPECFILE_SUBPACKAGE_VIDEO ?= ${ROOTDIR}/rpm/radio/radio.spec
+SPECFILE_SUBPACKAGE_RADIO ?= ${ROOTDIR}/rpm/radio/radio.spec
 
 .PHONY: dist
 dist: ##             - Creates the QM radio package
@@ -12,7 +12,7 @@ dist: ##             - Creates the QM radio package
 		../qm/README.md \
 		../qm/SECURITY.md \
 		../qm/LICENSE \
-                ../qm/etc/containers/systemd/qm.container.d/qm_dropin_mount_bind_radio.conf
+        ../qm/etc/containers/systemd/qm.container.d/qm_dropin_mount_bind_radio.conf
 	cd $(ROOTDIR) && mv /tmp/qm-radio-${VERSION}.tar.gz ./rpm
 
 


### PR DESCRIPTION
- Fix subpackages currently failing to build
- Also address subpackage naming consistency

## Summary by Sourcery

Fix and standardize subpackage configuration and naming across various system components

Bug Fixes:
- Corrected build paths and specfile references for radio and DVB subpackages
- Fixed incorrect version string in DVB package build configuration

Enhancements:
- Standardized RPM package naming convention for input and ttyUSB0 subpackages