### PR TITLE
improve deny_set_scheduler

### DIFF
--- a/create-seccomp-rules
+++ b/create-seccomp-rules
@@ -37,11 +37,69 @@ function add_syscall_deny_list() {
     local syscall_name="$1"
     local seccomp_file_path="$2"
 
+    local temp_file
     temp_file=$(mktemp)
-    jq --tab \
-       --arg syscall "$syscall_name" \
-       '.syscalls += [{"names": [$syscall], "action": "SCMP_ACT_ERRNO", "args": [], "errnoRet": 1, "errno": "EPERM"}]' \
-       "${seccomp_file_path}" > "$temp_file" && mv "$temp_file" "${seccomp_file_path}"
+
+    if [[ "$syscall_name" == "sched_setscheduler" ]]; then
+        jq --tab \
+           '.syscalls += [
+               {
+                   "names": ["sched_setscheduler"],
+                   "action": "SCMP_ACT_ALLOW",
+                   "args": [
+                       {
+                           "index": 1,
+                           "value": 0,
+                           "valueTwo": 0,
+                           "op": "SCMP_CMP_EQ"
+                       }
+                   ],
+                   "comment": "",
+                   "includes": {},
+                   "excludes": {}
+               },
+               {
+                   "names": ["sched_setscheduler"],
+                   "action": "SCMP_ACT_ALLOW",
+                   "args": [
+                       {
+                           "index": 1,
+                           "value": 3,
+                           "valueTwo": 0,
+                           "op": "SCMP_CMP_EQ"
+                       }
+                   ],
+                   "comment": "",
+                   "includes": {},
+                   "excludes": {}
+               },
+               {
+                   "names": ["sched_setscheduler"],
+                   "action": "SCMP_ACT_ALLOW",
+                   "args": [
+                       {
+                           "index": 1,
+                           "value": 5,
+                           "valueTwo": 0,
+                           "op": "SCMP_CMP_EQ"
+                       }
+                   ],
+                   "comment": "",
+                   "includes": {},
+                   "excludes": {}
+               }
+           ]' "$seccomp_file_path" > "$temp_file" && mv "$temp_file" "$seccomp_file_path"
+    else
+        jq --tab \
+           --arg syscall "$syscall_name" \
+           '.syscalls += [{
+               "names": [$syscall],
+               "action": "SCMP_ACT_ERRNO",
+               "args": [],
+               "errnoRet": 1,
+               "errno": "EPERM"
+           }]' "$seccomp_file_path" > "$temp_file" && mv "$temp_file" "$seccomp_file_path"
+    fi
 
     rm "$temp_file" &> /dev/null
 }

--- a/qm.fc
+++ b/qm.fc
@@ -11,3 +11,6 @@
 
 # File context for ipc programs
 /var/run/ipc(/.*)?	gen_context(system_u:object_r:ipc_var_run_t,s0)
+
+# File context for bluechi-agent inside QM
+/usr/lib/qm/rootfs/usr/libexec/bluechi-agent	--	gen_context(system_u:object_r:qm_bluechi_agent_exec_t,s0)

--- a/qm.te
+++ b/qm.te
@@ -30,11 +30,56 @@ unconfined_domain(ipc_t)
 
 qm_domain_template(qm)
 
+
+
+#########################################
+#
+# bluechi-agent inside QM
+#
+
+type qm_bluechi_agent_t;
+type qm_bluechi_agent_exec_t;
+init_daemon_domain(qm_bluechi_agent_t, qm_bluechi_agent_exec_t)
+
+allow qm_bluechi_agent_t qm_file_t:chr_file read;
+allow qm_bluechi_agent_t qm_file_t:dir { open read search getattr };
+allow qm_bluechi_agent_t qm_file_t:file { execute getattr open read };
+allow qm_bluechi_agent_t qm_file_t:file map;
+allow qm_bluechi_agent_t qm_file_t:lnk_file read;
+allow qm_bluechi_agent_t qm_file_t:sock_file write;
+allow qm_bluechi_agent_t qm_t:unix_dgram_socket sendto;
+allow qm_bluechi_agent_t qm_t:unix_stream_socket connectto;
+allow qm_bluechi_agent_t self:unix_dgram_socket { create getopt setopt };
+allow qm_bluechi_agent_t self:tcp_socket create_stream_socket_perms;
+
+allow qm_bluechi_agent_t qm_t:dbus { send_msg acquire_svc };
+allow qm_bluechi_agent_t qm_t:system status;
+allow qm_bluechi_agent_t qm_t:system { reload start stop status };
+allow qm_bluechi_agent_t qm_file_t:service { reload start stop status };
+
+allow qm_t qm_bluechi_agent_t:dir search;
+allow qm_t qm_bluechi_agent_t:file { getattr ioctl open read };
+allow qm_t qm_bluechi_agent_t:lnk_file read;
+allow qm_t qm_bluechi_agent_t:dbus send_msg;
+allow qm_t qm_bluechi_agent_t:process { signull signal sigkill };
+
+unconfined_server_stream_connectto(qm_bluechi_agent_t)
+
+# Allow qm_bluechi_agent_t to connect to any port instead of labelled ones.
+gen_tunable(qm_bluechi_agent_port_connect_any, true)
+
 optional_policy(`
 	require{
 		type bluechi_var_run_t;
+		type bluechi_agent_port_t;
 		type bluechi_t;
 	}
-	stream_connect_pattern(qm_t, bluechi_var_run_t, bluechi_var_run_t, bluechi_t)
-	unconfined_server_stream_connectto(qm_t)
+
+	tunable_policy(`qm_bluechi_agent_port_connect_any',`
+		corenet_tcp_connect_all_ports(qm_bluechi_agent_t)
+	',`
+		allow qm_bluechi_agent_t bluechi_agent_port_t:tcp_socket name_connect;
+	')
+
+	stream_connect_pattern(qm_bluechi_agent_t, bluechi_var_run_t, bluechi_var_run_t, bluechi_t)
 ')

--- a/tests/e2e/tools/FFI/deny_set_scheduler/execute_set_scheduler.c
+++ b/tests/e2e/tools/FFI/deny_set_scheduler/execute_set_scheduler.c
@@ -27,7 +27,7 @@ int main(int argc, char *argv[]) {
         } else if (strcmp(policy_name, "SCHED_RR")==0) {
             policy = SCHED_RR;
         } else {
-            printf("Unknow policy.\n");
+            printf("Unknown policy.\n");
             return EXIT_FAILURE;
         }
     }

--- a/tests/e2e/tools/FFI/deny_set_scheduler/execute_set_scheduler.c
+++ b/tests/e2e/tools/FFI/deny_set_scheduler/execute_set_scheduler.c
@@ -1,3 +1,4 @@
+#define _GNU_SOURCE
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -5,24 +6,55 @@
 #include <errno.h>
 #include <string.h>
 
-int main() {
+int main(int argc, char *argv[]) {
     int pid = getpid();
-    int policy = SCHED_FIFO;  // Desired scheduling policy
+    int policy;  // Desired scheduling policy
+    char *policy_name;
     struct sched_param param;
 
-    // Assign the maximum priority for the SCHED_FIFO policy
+    if (argc == 2)
+    {
+        policy_name = argv[1];
+
+        if (strcmp(policy_name, "SCHED_OTHER")==0) {
+            policy = SCHED_OTHER;
+        } else if (strcmp(policy_name, "SCHED_BATCH")==0) {
+            policy = SCHED_BATCH;
+        } else if (strcmp(policy_name, "SCHED_IDLE")==0) {
+            policy = SCHED_IDLE;
+        } else if (strcmp(policy_name, "SCHED_FIFO")==0) {
+            policy = SCHED_FIFO;
+        } else if (strcmp(policy_name, "SCHED_RR")==0) {
+            policy = SCHED_RR;
+        } else {
+            printf("Unknow policy.\n");
+            return EXIT_FAILURE;
+        }
+    }
+    else if (argc > 2)
+    {
+        printf("Too many policies supplied.\n");
+        return EXIT_FAILURE;
+    }
+    else
+    {
+        printf("One policy expected.\n");
+        return EXIT_FAILURE;
+    }
+
+    // Assign the maximum priority for the policy
     param.sched_priority = sched_get_priority_max(policy);
     if (param.sched_priority == -1) {
-        fprintf(stderr, "Failed to get max priority for SCHED_FIFO: %s\n", strerror(errno));
+        fprintf(stderr, "Failed to get max priority for %s: %s\n", policy_name, strerror(errno));
         return EXIT_FAILURE;
     }
 
     // Attempt to set the scheduling policy and priority
     if (sched_setscheduler(pid, policy, &param) == -1) {
-        fprintf(stderr, "Failed to set scheduler: %s\n", strerror(errno));
+        printf("sched_setscheduler(%s) failed: errno=%d (%s)", policy_name, errno, strerror(errno));
         return EXIT_FAILURE;
+    } else {
+        printf("sched_setscheduler(%s) succeeded.", policy_name);
+        return EXIT_SUCCESS;
     }
-
-    printf("Scheduler set to SCHED_FIFO with priority %d\n", param.sched_priority);
-    return EXIT_SUCCESS;
 }

--- a/tests/ffi/deny_set_scheduler/test.sh
+++ b/tests/ffi/deny_set_scheduler/test.sh
@@ -3,7 +3,8 @@
 # shellcheck source=tests/ffi/common/prepare.sh
 . ../common/prepare.sh
 
-expected_result="Failed to set scheduler: Function not implemented"
+policy_arr=(SCHED_OTHER SCHED_BATCH SCHED_IDLE SCHED_FIFO SCHED_RR)
+num_of_failed_policy=0
 
 trap disk_cleanup EXIT
 prepare_test
@@ -11,11 +12,32 @@ reload_config
 
 running_container_in_qm
 
-return_from_setscheduler=$(podman exec -it qm /usr/bin/podman exec -it ffi-qm ./QM/test_sched_setscheduler)
+for policy in "${policy_arr[@]}"; do
+    return_from_setscheduler=$(podman exec -it qm /usr/bin/podman exec -it ffi-qm ./QM/test_sched_setscheduler "$policy")
 
-if [[ "${return_from_setscheduler}" =~ ${expected_result} ]]; then
-    info_message "PASS: set_scheduler() syscall denied in QM."
-else
-    info_message "FAIL: set_scheduler() syscall can be executed in QM."
+    # Assign the expected result according to the policy
+    if [[ "$policy" == "SCHED_OTHER" || "$policy" == "SCHED_BATCH" || "$policy" == "SCHED_IDLE" ]]; then
+        expected_result="sched_setscheduler($policy) succeeded."
+    elif [[ "$policy" == "SCHED_FIFO" || "$policy" == "SCHED_RR" ]]; then
+        expected_result="sched_setscheduler($policy) failed: errno=38 (Function not implemented)"
+    fi
+
+    # Check that the result is the same as expected
+    if [[ "${return_from_setscheduler}" == "${expected_result}" ]]; then
+        info_message "$expected_result"
+        info_message "PASS: The result of sched_setscheduler($policy) is as expected in QM."
+    else
+        info_message "$return_from_setscheduler"
+        info_message "FAIL: The result of sched_setscheduler($policy) is not what is expected in QM."
+        ((num_of_failed_policy++))
+    fi
+done
+
+# If there is a failed policy, then this test returns failure
+if [[ $num_of_failed_policy -gt 0 ]]; then
+    info_message "FAIL: sched_setscheduler() test failed."
     exit 1
+else
+    info_message "PASS: sched_setscheduler() test passed."
+    exit 0
 fi

--- a/tests/ffi/deny_set_scheduler/test.sh
+++ b/tests/ffi/deny_set_scheduler/test.sh
@@ -3,7 +3,7 @@
 # shellcheck source=tests/ffi/common/prepare.sh
 . ../common/prepare.sh
 
-expected_result="Failed to set scheduler: Operation not permitted"
+expected_result="Failed to set scheduler: Function not implemented"
 
 trap disk_cleanup EXIT
 prepare_test


### PR DESCRIPTION
Test `sched_setscheduler` with policies: policy==SCHED_OTHER / BATCH / IDLE / SCHED_FIFO / SCHED_RR according to PR #824 
Resolves: #826 

## Summary by Sourcery

Generalize the deny_set_scheduler test tool and its script to handle multiple scheduling policies, verify proper denial or allowance in the QM environment, and report detailed results for each policy.

New Features:
- Add support in execute_set_scheduler to test sched_setscheduler for SCHED_OTHER, SCHED_BATCH, SCHED_IDLE, SCHED_FIFO, and SCHED_RR via command-line argument

Enhancements:
- Implement policy name parsing and mapping in the test utility and improve its success/failure messages
- Refactor test.sh to dynamically iterate over all supported policies and validate each syscall result

Tests:
- Update end-to-end test script to accumulate per-policy pass/fail outcomes and exit with overall status