### PR TITLE
Qmctl tests

### DIFF
--- a/plans/e2e/kvm-tier-0.fmf
+++ b/plans/e2e/kvm-tier-0.fmf
@@ -2,7 +2,7 @@ summary: Kvm Tier 0 - QM sanity test
 
 discover:
     how: fmf
-    filter: 'tier:0&tag:kvm'
+    filter: 'tier:0&tag:kvm|tier:0&tag:qmctl-test'
 
 prepare+:
     - name: Enable copr and install rpms

--- a/tests/qmctl-test/files/file-to-check-cp.txt
+++ b/tests/qmctl-test/files/file-to-check-cp.txt
@@ -1,0 +1,1 @@
+output: This is the file to copy

--- a/tests/qmctl-test/files/file-to-copy.txt
+++ b/tests/qmctl-test/files/file-to-copy.txt
@@ -1,0 +1,1 @@
+This is the file to copy

--- a/tests/qmctl-test/main.fmf
+++ b/tests/qmctl-test/main.fmf
@@ -1,0 +1,7 @@
+summary: Test plan for QMCTL using TMT
+test: ./test_qmctl.sh
+duration: 10m
+tag: qmctl-test
+tier: 0
+framework: shell
+id: 9b3f962e-758a-473b-b8ea-540a177b9134

--- a/tests/qmctl-test/scripts/qmctl_cp.sh
+++ b/tests/qmctl-test/scripts/qmctl_cp.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# shellcheck disable=SC1091
+. ../e2e/lib/utils
+
+QMCTL_SCRIPT="../../tools/qmctl/qmctl"
+
+python3 $QMCTL_SCRIPT cp ./files/file-to-copy.txt qm:/tmp
+
+expected_output_file="./files/file-to-check-cp.txt"
+actual_output_temp_file=$(mktemp)
+
+python3 $QMCTL_SCRIPT exec cat /tmp/file-to-copy.txt > "$actual_output_temp_file"
+
+if diff "$actual_output_temp_file" "$expected_output_file" > /dev/null; then
+  info_message "The output matches the content of '$expected_output_file'."
+  info_message "PASS: qmctl cp command executed successfully"
+  exit 0
+else
+  echo "FAIL: The output does NOT match the content of '$expected_output_file'."
+  exit 1
+fi

--- a/tests/qmctl-test/scripts/qmctl_exec.sh
+++ b/tests/qmctl-test/scripts/qmctl_exec.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# shellcheck disable=SC1091
+. ../e2e/lib/utils
+
+QMCTL_SCRIPT="../../tools/qmctl/qmctl"
+
+if python3 $QMCTL_SCRIPT exec podman ps -a | grep -q "alpine-podman"; then
+    echo "FAIL: podman named alpine-container already exists"
+    exit 1
+fi
+
+python3 $QMCTL_SCRIPT exec podman run -d --name alpine-podman alpine tail -f /dev/null
+
+if ! python3 $QMCTL_SCRIPT exec podman ps -a | grep -q "alpine-podman"; then
+    echo "FAIL: podman container was not created"
+    exit 1
+fi
+
+info_message "PASS: qmctl exec command executed successfully"
+exit 0

--- a/tests/qmctl-test/scripts/qmctl_execin.sh
+++ b/tests/qmctl-test/scripts/qmctl_execin.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# shellcheck disable=SC1091
+. ../e2e/lib/utils
+
+QMCTL_SCRIPT="../../tools/qmctl/qmctl"
+
+tmp_file="/tmp/file-execin.txt"
+if python3 $QMCTL_SCRIPT execin alpine-podman ls -la /tmp/ | grep -q $tmp_file; then
+    echo "FAIL: The file /tmp/file-execin.txt already exists"
+    exit 1
+fi
+
+python3 $QMCTL_SCRIPT execin alpine-podman touch /tmp/file-execin.txt
+
+if ! python3 $QMCTL_SCRIPT execin alpine-podman cat /tmp/file-execin.txt; then
+    echo "FAIL: The file /tmp/file-execin.txt was not created"
+    exit 1
+fi
+
+info_message "PASS: qmctl execin command executed successfully"
+exit 0

--- a/tests/qmctl-test/scripts/qmctl_show.sh
+++ b/tests/qmctl-test/scripts/qmctl_show.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# shellcheck disable=SC1091
+. ../e2e/lib/utils
+
+QMCTL_SCRIPT="../../tools/qmctl/qmctl"
+
+expected_output_file="/usr/share/containers/systemd/qm.container"
+actual_output_temp_file=$(mktemp)
+
+python3 $QMCTL_SCRIPT show > "$actual_output_temp_file"
+
+if diff "$actual_output_temp_file" "$expected_output_file" > /dev/null; then
+  info_message "The output matches the content of '$expected_output_file'."
+  info_message "PASS: qmctl show command executed successfully"
+  exit 0
+else
+  echo "FAIL: The output does NOT match the content of '$expected_output_file'."
+  exit 1
+fi

--- a/tests/qmctl-test/test_qmctl.sh
+++ b/tests/qmctl-test/test_qmctl.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# shellcheck disable=SC1091
+. ../e2e/lib/utils
+
+info_message "Running qmctl command..."
+
+QMCTL_SCRIPT="../../tools/qmctl/qmctl"
+
+if [ ! -f "$QMCTL_SCRIPT" ]; then
+  echo "FAIL: qmctl script not found at $QMCTL_SCRIPT"
+  exit 1
+fi
+
+if ! ./scripts/qmctl_show.sh ; then
+  echo "FAIL: qmctl show failed."
+  exit 1
+fi
+
+if ! ./scripts/qmctl_exec.sh; then
+  echo "FAIL: qmctl exec failed."
+  exit 1
+fi
+
+if ! ./scripts/qmctl_execin.sh; then
+  echo "FAIL: qmctl execin failed."
+  exit 1
+fi
+
+if ! ./scripts/qmctl_cp.sh; then
+  echo "FAIL: qmctl cp failed."
+  exit 1
+fi


### PR DESCRIPTION
Closes: https://issues.redhat.com/browse/VROOM-28614

## Summary by Sourcery

Add tmt tests to check qmctl functionality ( cp, show, exec and ecexin). First, the test install and set up QM, and then run the scripts that check the output of each of the qm commands.

Tests:
- 'qmctl_cp.sh' runs the `qmctl cp` command and copy `file_to_copy.txt` into QM and compares the text inside the file that was created.
- `qmctl_exec.cp` runs the `qmctl exec` command that creates and new Alpine container and check if it was created inside QM
- `qmctl_execin.sh` runs the `qmctl execin` command that creates a new file inside the new Alpine container  and checks if it was really created
- `qmctl_show.sh`  runs the `qmctl show` command that saves its output into a file, and compares it to the expected file 