### PR TITLE
Improve subpackage CI/CD rpm build process and error handling

### DIFF
--- a/.github/workflows/check-subpackages.yml
+++ b/.github/workflows/check-subpackages.yml
@@ -19,15 +19,24 @@ jobs:
 
       - name: Run make for each subsystem
         run: |
+          subsystem_build_failures=()
           for dir in subsystems/*; do
-            if [ -d "$dir" ]; then
-              subsystem=$(basename "$dir")
-              echo "Running make for $subsystem..."
-              make TARGETS=$subsystem subpackages
-              if [ $? -ne 0 ]; then
-                echo "❌ Make failed for $subsystem" >&2
-                exit 1
+              if [ -d "$dir" ]; then
+                  subsystem=$(basename "$dir")
+                  echo "Running make for $subsystem..."
+                  make TARGETS=$subsystem subpackages
+                  if [ $? -ne 0 ]; then
+                      subsystem_build_failures+=("$subsystem")
+                      echo "❌ Make failed for $subsystem" >&2
+                  fi
               fi
-            fi
           done
+          if (( ${#subsystem_build_failures[@]} == 0 )); then
+              echo "✅ All subsystems built successfully"; \
+              exit 0;
+          else
+              echo "❌ The following subsystems failed to build: ";
+              echo -e "\t${subsystem_build_failures[@]}" | tr ' ' ', ';
+              exit 1;
+          fi
 

--- a/subsystems/dvb/Makefile
+++ b/subsystems/dvb/Makefile
@@ -2,6 +2,7 @@ RPM_TOPDIR ?= $(PWD)/rpmbuild
 VERSION ?= $(shell cat VERSION)
 ROOTDIR ?= $(PWD)
 SPECFILE_SUBPACKAGE_DVB ?= ${ROOTDIR}/rpm/dvb/dvb.spec
+PACKAGE_NAME = qm-mount-bind-dvb
 
 .PHONY: dist
 dist: ##             - Creates the QM dvb package
@@ -24,4 +25,8 @@ dvb: dist ##             - Creates a local RPM package, useful for development
 		--define="_topdir ${RPM_TOPDIR}" \
 		--define="version ${VERSION}" \
 		${SPECFILE_SUBPACKAGE_DVB}
+	if [ ! -f ${RPM_TOPDIR}/RPMS/noarch/${PACKAGE_NAME}-${VERSION}*.noarch.rpm ]; then \
+		echo "rpmbuild failed to build: ${PACKAGE_NAME}"; \
+		exit 1; \
+	fi
 

--- a/subsystems/input/Makefile
+++ b/subsystems/input/Makefile
@@ -2,6 +2,7 @@ RPM_TOPDIR ?= $(PWD)/rpmbuild
 VERSION ?= $(shell cat VERSION)
 ROOTDIR ?= $(PWD)
 SPECFILE_SUBPACKAGE_INPUT ?= ${ROOTDIR}/rpm/input/input.spec
+PACKAGE_NAME = qm-mount-bind-input
 
 .PHONY: dist
 dist: ##             - Creates the QM input package
@@ -24,3 +25,7 @@ input:  dist ##             - Creates a local RPM package, useful for developmen
 		--define="_topdir ${RPM_TOPDIR}" \
 		--define="version ${VERSION}" \
 		${SPECFILE_SUBPACKAGE_INPUT}
+	if [ ! -f ${RPM_TOPDIR}/RPMS/noarch/${PACKAGE_NAME}-${VERSION}*.noarch.rpm ]; then \
+		echo "rpmbuild failed to build: ${PACKAGE_NAME}"; \
+		exit 1; \
+	fi

--- a/subsystems/kvm/Makefile
+++ b/subsystems/kvm/Makefile
@@ -2,6 +2,7 @@ RPM_TOPDIR ?= $(PWD)/rpmbuild
 VERSION ?= $(shell cat VERSION)
 ROOTDIR ?= $(PWD)
 SPECFILE_SUBPACKAGE_IMG_KVM ?= ${ROOTDIR}/rpm/kvm/qm-kvm.spec
+PACKAGE_NAME = qm-kvm
 
 .PHONY: dist
 dist: ##             - Creates the QM kvm package
@@ -32,4 +33,7 @@ kvm: dist ##             - Creates a local RPM kvm package, useful for developme
 		--define="_topdir ${RPM_TOPDIR}" \
 		--define="version ${VERSION}" \
 		${SPECFILE_SUBPACKAGE_IMG_KVM}
-
+	if [ ! -f ${RPM_TOPDIR}/RPMS/noarch/${PACKAGE_NAME}-${VERSION}*.noarch.rpm ]; then \
+		echo "rpmbuild failed to build: ${PACKAGE_NAME}"; \
+		exit 1; \
+	fi

--- a/subsystems/radio/Makefile
+++ b/subsystems/radio/Makefile
@@ -2,6 +2,7 @@ RPM_TOPDIR ?= $(PWD)/rpmbuild
 VERSION ?= $(shell cat VERSION)
 ROOTDIR ?= $(PWD)
 SPECFILE_SUBPACKAGE_RADIO ?= ${ROOTDIR}/rpm/radio/radio.spec
+PACKAGE_NAME = qm-mount-bind-radio
 
 .PHONY: dist
 dist: ##             - Creates the QM radio package
@@ -25,4 +26,7 @@ radio: dist ##             - Creates a local RPM package, useful for development
 		--define="_topdir ${RPM_TOPDIR}" \
 		--define="version ${VERSION}" \
 		${SPECFILE_SUBPACKAGE_RADIO}
-
+	if [ ! -f ${RPM_TOPDIR}/RPMS/noarch/${PACKAGE_NAME}-${VERSION}*.noarch.rpm ]; then \
+		echo "rpmbuild failed to build: ${PACKAGE_NAME}"; \
+		exit 1; \
+	fi

--- a/subsystems/ros2/Makefile
+++ b/subsystems/ros2/Makefile
@@ -2,6 +2,7 @@ RPM_TOPDIR ?= $(PWD)/rpmbuild
 VERSION ?= $(shell cat VERSION)
 ROOTDIR ?= $(PWD)
 SPECFILE_SUBPACKAGE_ROS2_ROLLING ?= ${ROOTDIR}/rpm/ros2/ros2_rolling.spec
+PACKAGE_NAME = qm-ros2
 
 .PHONY: dist
 dist: ##             - Creates the QM ros2 package
@@ -31,4 +32,7 @@ ros2: dist ##          - Creates a local RPM package, useful for development
 		--define="_topdir ${RPM_TOPDIR}" \
 		--define="version ${VERSION}" \
 		${SPECFILE_SUBPACKAGE_ROS2_ROLLING}
-
+	if [ ! -f ${RPM_TOPDIR}/RPMS/noarch/${PACKAGE_NAME}-${VERSION}*.noarch.rpm ]; then \
+		echo "rpmbuild failed to build: ${PACKAGE_NAME}"; \
+		exit 1; \
+	fi

--- a/subsystems/sound/Makefile
+++ b/subsystems/sound/Makefile
@@ -2,6 +2,7 @@ RPM_TOPDIR ?= $(PWD)/rpmbuild
 VERSION ?= $(shell cat VERSION)
 ROOTDIR ?= $(PWD)
 SPECFILE_SUBPACKAGE_SOUND ?= ${ROOTDIR}/rpm/sound/sound.spec
+PACKAGE_NAME = qm-sound
 
 .PHONY: dist
 dist: ##             - Creates the QM sound package
@@ -31,4 +32,7 @@ sound: dist ##             - Creates a local RPM package, useful for development
 		--define="_topdir ${RPM_TOPDIR}" \
 		--define="version ${VERSION}" \
 		${SPECFILE_SUBPACKAGE_SOUND}
-
+	if [ ! -f ${RPM_TOPDIR}/RPMS/noarch/${PACKAGE_NAME}-${VERSION}*.noarch.rpm ]; then \
+		echo "rpmbuild failed to build: ${PACKAGE_NAME}"; \
+		exit 1; \
+	fi

--- a/subsystems/text2speech/Makefile
+++ b/subsystems/text2speech/Makefile
@@ -2,6 +2,7 @@ RPM_TOPDIR ?= $(PWD)/rpmbuild
 VERSION ?= $(shell cat VERSION)
 ROOTDIR ?= $(PWD)
 SPECFILE_SUBPACKAGE_TEXT2SPEECH ?= ${ROOTDIR}/rpm/text2speech/text2speech.spec
+PACKAGE_NAME = qm-text2speech
 
 .PHONY: dist
 dist: ##             - Creates the QM input package
@@ -30,3 +31,7 @@ text2speech: dist ##            - Creates a local RPM package, useful for develo
 		--define="_topdir ${RPM_TOPDIR}" \
 		--define="version ${VERSION}" \
 		${SPECFILE_SUBPACKAGE_TEXT2SPEECH}
+	if [ ! -f ${RPM_TOPDIR}/RPMS/noarch/${PACKAGE_NAME}-${VERSION}*.noarch.rpm ]; then \
+		echo "rpmbuild failed to build: ${PACKAGE_NAME}"; \
+		exit 1; \
+	fi

--- a/subsystems/tty7/Makefile
+++ b/subsystems/tty7/Makefile
@@ -2,6 +2,7 @@ RPM_TOPDIR ?= $(PWD)/rpmbuild
 VERSION ?= $(shell cat VERSION)
 ROOTDIR ?= $(PWD)
 SPECFILE_SUBPACKAGE_TTY7 ?= ${ROOTDIR}/rpm/tty7/tty7.spec
+PACKAGE_NAME = qm-mount-bind-tty7
 
 .PHONY: dist
 dist: ##             - Creates the QM tty7 package
@@ -30,4 +31,7 @@ tty7: dist ##             - Creates a local RPM package, useful for development
 		--define="_topdir ${RPM_TOPDIR}" \
 		--define="version ${VERSION}" \
 		${SPECFILE_SUBPACKAGE_TTY7}
-
+	if [ ! -f ${RPM_TOPDIR}/RPMS/noarch/${PACKAGE_NAME}-${VERSION}*.noarch.rpm ]; then \
+		echo "rpmbuild failed to build: ${PACKAGE_NAME}"; \
+		exit 1; \
+	fi

--- a/subsystems/ttyUSB0/Makefile
+++ b/subsystems/ttyUSB0/Makefile
@@ -2,6 +2,7 @@ RPM_TOPDIR ?= $(PWD)/rpmbuild
 VERSION ?= $(shell cat VERSION)
 ROOTDIR ?= $(PWD)
 SPECFILE_SUBPACKAGE_TTYUSB0 ?= ${ROOTDIR}/rpm/ttyUSB0/ttyUSB0.spec
+PACKAGE_NAME = qm-mount-bind-ttyUSB0
 
 .PHONY: dist
 dist: ##             - Creates the QM ttyUSB0 package
@@ -30,4 +31,7 @@ ttyUSB0: dist ##             - Creates a local RPM package, useful for developme
 		--define="_topdir ${RPM_TOPDIR}" \
 		--define="version ${VERSION}" \
 		${SPECFILE_SUBPACKAGE_TTYUSB0}
-
+	if [ ! -f ${RPM_TOPDIR}/RPMS/noarch/${PACKAGE_NAME}-${VERSION}*.noarch.rpm ]; then \
+		echo "rpmbuild failed to build: ${PACKAGE_NAME}"; \
+		exit 1; \
+	fi

--- a/subsystems/video/Makefile
+++ b/subsystems/video/Makefile
@@ -2,6 +2,7 @@ RPM_TOPDIR ?= $(PWD)/rpmbuild
 VERSION ?= $(shell cat VERSION)
 ROOTDIR ?= $(PWD)
 SPECFILE_SUBPACKAGE_VIDEO ?= ${ROOTDIR}/rpm/video/video.spec
+PACKAGE_NAME = qm-mount-bind-video
 
 .PHONY: dist
 dist: ##             - Creates the QM video package
@@ -31,4 +32,7 @@ video: dist ##             - Creates a local RPM package, useful for development
 		--define="_topdir ${RPM_TOPDIR}" \
 		--define="version ${VERSION}" \
 		${SPECFILE_SUBPACKAGE_VIDEO}
-
+	if [ ! -f ${RPM_TOPDIR}/RPMS/noarch/${PACKAGE_NAME}-${VERSION}*.noarch.rpm ]; then \
+		echo "rpmbuild failed to build: ${PACKAGE_NAME}"; \
+		exit 1; \
+	fi

--- a/subsystems/windowmanager/Makefile
+++ b/subsystems/windowmanager/Makefile
@@ -2,6 +2,7 @@ RPM_TOPDIR ?= $(PWD)/rpmbuild
 VERSION ?= $(shell cat VERSION)
 ROOTDIR ?= $(PWD)
 SPECFILE_SUBPACKAGE_IMG_WINDOWMANAGER ?= ${ROOTDIR}/rpm/windowmanager/windowmanager.spec
+PACKAGE_NAME = qm-windowmanager
 
 .PHONY: dist
 dist: ##             - Creates the QM windowmanager package
@@ -28,4 +29,7 @@ windowmanager: dist ##         - Creates a local windowmanager package, useful f
 		--define="_topdir ${RPM_TOPDIR}" \
 		--define="version ${VERSION}" \
 		${SPECFILE_SUBPACKAGE_IMG_WINDOWMANAGER}
-
+	if [ ! -f ${RPM_TOPDIR}/RPMS/noarch/${PACKAGE_NAME}-${VERSION}*.noarch.rpm ]; then \
+		echo "rpmbuild failed to build: ${PACKAGE_NAME}"; \
+		exit 1; \
+	fi


### PR DESCRIPTION
Add explicit RPM existence checks after builds in subsystem Makefiles to ensure successful subpackage creation.

## Summary by Sourcery

Improve the RPM subpackage build pipeline by enforcing post-build artifact checks in each subsystem Makefile and updating the CI workflow to aggregate and report all build failures.

Enhancements:
- Add PACKAGE_NAME definitions and post-build file existence checks in each subsystem’s Makefile to fail if the expected RPM is missing.

CI:
- Update GitHub Actions job to collect subsystem build failures and output a consolidated success or failure report instead of exiting on the first error.