### PR TITLE
selinux ipc: use macro to allow communication

### DIFF
--- a/qm.te
+++ b/qm.te
@@ -31,6 +31,11 @@ unconfined_domain(ipc_t)
 qm_domain_template(qm)
 
 
+#########################################
+#
+# IPC between two QM containers
+#
+stream_connect_pattern(qm_container_ipc_t, ipc_var_run_t, qm_file_t, qm_t);
 
 #########################################
 #


### PR DESCRIPTION
Allow communication between two ASIL-QM containers using IPC.



## Summary by Sourcery

Enhancements:
- Replace manual IPC permission rules in qm.te with a SELinux macro invocation to allow inter-container communication