### PR TITLE
Add filetrans rule for ipc_var_run_t directory named ipc

### DIFF
--- a/qm.fc
+++ b/qm.fc
@@ -10,6 +10,7 @@
 /etc/qm(/.*)?	gen_context(system_u:object_r:qm_file_t,s0)
 
 # File context for ipc programs
+/usr/lib/qm/rootfs/run/ipc(/.*)?	gen_context(system_u:object_r:ipc_var_run_t,s0)
 /run/ipc(/.*)?	gen_context(system_u:object_r:ipc_var_run_t,s0)
 
 # File context for bluechi-agent inside QM

--- a/qm.if
+++ b/qm.if
@@ -83,6 +83,7 @@ template(`qm_domain_template',`
 	allow $1_t $1_file_type:chr_file mounton;
 	allow $1_t $1_file_type:sock_file mounton;
 
+	filetrans_pattern(ipc_t, $1_file_t, ipc_var_run_t, dir, "ipc")
 	list_dirs_pattern($1_t, ipc_var_run_t, ipc_var_run_t)
 	allow $1_t ipc_var_run_t:dir mounton;
 


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Add SELinux filetrans rule for directories named 'ipc' to assign the `ipc_var_run_t` security context.