### PR TITLE
qm.te: add allow for IPC (qm to qm)

### DIFF
--- a/qm.if
+++ b/qm.if
@@ -414,6 +414,16 @@ template(`qm_domain_template',`
 	allow $1_t $1_container_wayland_t:dbus send_msg;
 	dev_read_sysfs($1_container_wayland_t)
 
+        #########################################
+        #
+        #   QM to QM IPC Communication
+        #
+        # Allow rw access to sock files labeled qm_file_t
+        allow $1_container_t $1_file_t:sock_file { read write };
+        # Allow container to connect to unix_stream_socket of qm_t processes
+        allow $1_container_t $1_t:unix_stream_socket connectto;
+
+
 	allow getty_t $1_file_type:chr_file rw_chr_file_perms;
 
 	read_files_pattern(systemd_hostnamed_t, $1_file_t, $1_file_t)


### PR DESCRIPTION
## Summary by Sourcery
fix #840 
ipc communication inside QM
as documented in 
[qm-to-app](https://github.com/containers/qm/blob/c4f1ed9cf0ba10acd2ec38ff84264d68e98da0c2/docs/docs/ipc.md#example-qm-to-qm-app)

New Features:
- Permit IPC communication between qm processes in the SELinux policy