### PR TITLE
qm.if: allow process setcurrent for qm_t

### DIFF
--- a/qm.if
+++ b/qm.if
@@ -15,6 +15,7 @@ template(`qm_domain_template',`
 	gen_require(`
 		class dbus { send_msg acquire_svc };
 		class passwd rootok;
+		class process setcurrent;
 
 		attribute container_domain;
 		attribute filesystem_type;
@@ -60,6 +61,7 @@ template(`qm_domain_template',`
 	container_exec_share_files($1_t)
 	allow $1_t container_ro_file_t:file execmod;
 	allow $1_container_domain $1_file_type:chr_file { rw_inherited_file_perms };
+	allow $1_t self:process setcurrent;
 
 	attribute $1_file_type;
 	allow $1_file_type self:filesystem associate;

--- a/tests/qm-kvm-test/libkrun/check_libkrun.sh
+++ b/tests/qm-kvm-test/libkrun/check_libkrun.sh
@@ -6,7 +6,6 @@ source ../../e2e/lib/utils
 enable_repo() {
     info_message "enable_repo(): enable repo"
     exec_cmd "cd /etc/yum.repos.d/"
-    exec_cmd "curl -O https://copr.fedorainfracloud.org/coprs/slp/autosd-krun/repo/centos-stream-9/slp-autosd-krun-centos-stream-9.repo"
     exec_cmd "dnf copr enable -y copr.fedorainfracloud.org/@centos-automotive-sig/libkrun centos-stream-9-$(arch)"
 }
 
@@ -15,43 +14,13 @@ install_libkrun() {
     exec_cmd "dnf install --setopt=reposdir=/etc/yum.repos.d  --installroot=/usr/lib/qm/rootfs -y libkrun crun-krun"
 }
 
-# This is a workaround to update the qm policy to add support for libkrun.
-# It should be removed after the qm policy is updated.
-update_qm_selinux_policy() {
-    info_message "update_qm_selinux_policy(): update the qm selinux policy"
-    touch /root/krun.te
-    cat > "/root/krun.te" << EOF
-module krun 1.0;
-
-require {
-	type qm_t;
-	class process setcurrent;
-}
-
-#============= qm_t ==============
-allow qm_t self:process setcurrent;
-EOF
-
-    exec_cmd "cd /root/"
-    exec_cmd "checkmodule -M -m -o krun.mod krun.te"
-    exec_cmd "semodule_package -o krun.pp -m krun.mod"
-    exec_cmd "semodule -i krun.pp"
-}
-
 check_libkrun() {
     info_message "check_libkrun(): run virtualization-isolated containers."
     exec_cmd "podman exec -it qm podman run --runtime=krun --rm -it alpine echo 'Hello libkrun.'"
     info_message "PASS: libkrun runs successfully."
 }
 
-remove_generated_files () {
-    exec_cmd "cd /root/ && rm -f  *.te *.mod *.pp"
-    exit 0
-}
-
 enable_repo
 install_libkrun
-update_qm_selinux_policy
 check_libkrun
-remove_generated_files
 


### PR DESCRIPTION
Update SELinux rules to support krun
runtime to work properly inside QM
container.

Update check_libkrun.sh test accordinly.

Fixes: https://github.com/containers/qm/issues/846

## Summary by Sourcery

Integrate krun support into QM’s SELinux policy and streamline the libkrun test script by eliminating temporary policy hacks and updating repository setup

Enhancements:
- Add SELinux rule in qm.if to allow qm_t processes to change process contexts (setcurrent)

Tests:
- Remove manual SELinux module generation and cleanup functions from check_libkrun.sh
- Remove direct .repo download and update repository enabling to use dnf copr enable