### PR TITLE
qm.spec: add validation for file context entries

### DIFF
--- a/rpm/qm.spec
+++ b/rpm/qm.spec
@@ -16,6 +16,11 @@
 # Format must contain '$x' somewhere to do anything useful
 %global _format() export %1=""; for x in %{modulenames}; do %1+=%2; %%1+=" "; done;
 
+# RHEL < 10 and Fedora < 40 use file context entries in /var/run
+%if %{defined rhel} && 0%{?rhel} < 10 || %{defined fedora} && 0%{?fedora} < 40
+%define legacy_var_run 1
+%endif
+
 # copr_username is only set on copr environments, not on others like koji
 # Check if copr is owned by rhcontainerbot
 %if "%{?copr_username}" != "rhcontainerbot"
@@ -90,6 +95,10 @@ use container tools like Podman.
 sed -i 's/^install: man all/install:/' Makefile
 
 %build
+%if %{defined legacy_var_run}
+sed -i 's|^/run/|/var/run/|' qm.fc
+%endif
+
 %{__make} all
 
 %install


### PR DESCRIPTION
RHEL < 10 and Fedora < 40 use file context entries in /var/run.

Fix #859 
need to use old /var/run for c9s

## Summary by Sourcery

Add conditional support in the RPM spec for legacy file context paths by mapping /run to /var/run on RHEL < 10 and Fedora < 40

Enhancements:
- Introduce a legacy_var_run macro to detect older RHEL and Fedora releases

Build:
- Conditionally apply a sed patch in qm.fc to replace /run/ with /var/run/ for legacy distributions

## Summary by Sourcery

Add conditional support for legacy file context paths by defining a legacy_var_run macro for pre-10 RHEL and pre-40 Fedora and patching qm.fc during build to use /var/run instead of /run on those distributions.

Bug Fixes:
- Ensure file context entries use /var/run on RHEL < 10 and Fedora < 40 to fix #859

Enhancements:
- Introduce legacy_var_run macro to detect older RHEL and Fedora releases

Build:
- Conditionally apply sed patch in build to map /run/ to /var/run/ in qm.fc for legacy distributions