### PR TITLE
qm.container: Limit max mqueues to 4

### DIFF
--- a/qm.container
+++ b/qm.container
@@ -91,6 +91,17 @@ Mount=type=tmpfs,destination=/dev/shm
 #
 Rootfs=${ROOTFS}
 
+# The value for fs.mqueue.queues_max determines the maximum number of POSIX message queues
+# that can be created system-wide within the container. This value is set based on available
+# system resources and the expected usage pattern. The calculation is approximately:
+#   queues_max ≈ (system-wide RLIMIT_MSGQUEUE) / (msg_max * msgsize_max) / 2
+# where:
+#   - RLIMIT_MSGQUEUE is the total bytes allowed for all message queues (ulimit -q)
+#   - msg_max is the maximum number of messages allowed per queue (msg_max)
+#   - msgsize_max is the maximum size of each message (msgsize_max)
+# The division by 2 provides a safety margin to avoid exhausting resources and grant FFI.
+Sysctl=fs.mqueue.queues_max=4
+
 SecurityLabelNested=true
 SecurityLabelFileType=qm_file_t
 SecurityLabelLevel=s0

--- a/tests/ffi/mqueue/Makefile
+++ b/tests/ffi/mqueue/Makefile
@@ -1,0 +1,31 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+CC = gcc
+CFLAGS = -Wall -Wextra -std=c99
+LDFLAGS = -lrt
+
+TARGETS = test_mqueue_limit test_host_mqueue
+SOURCES = test_mqueue_limit.c test_host_mqueue.c
+
+all: $(TARGETS)
+
+test_mqueue_limit: test_mqueue_limit.c
+	$(CC) $(CFLAGS) -o test_mqueue_limit test_mqueue_limit.c $(LDFLAGS)
+
+test_host_mqueue: test_host_mqueue.c
+	$(CC) $(CFLAGS) -o test_host_mqueue test_host_mqueue.c $(LDFLAGS)
+
+clean:
+	rm -f $(TARGETS)
+
+.PHONY: all clean

--- a/tests/ffi/mqueue/README.md
+++ b/tests/ffi/mqueue/README.md
@@ -1,0 +1,61 @@
+# FFI - Message Queue Limit Test
+
+This test verifies that the `fs.mqueue.queues_max=4` sysctl setting is properly applied in the QM container and that the limit is correctly enforced while the host maintains independent message queue capacity.
+
+## Test Overview
+
+The test validates message queue isolation by:
+
+1. **Host baseline**: Creates message queues on the host before container testing
+2. **Container limit verification**: Confirms QM container can create exactly 4 queues then hits limit
+3. **Host isolation verification**: Creates additional message queues on host after container limit reached
+4. **Comprehensive isolation**: Demonstrates that container limits don't affect host queue availability
+
+## Test Components
+
+### test_mqueue_limit.c
+
+A C program that runs inside the QM container:
+
+- Creates message queues using the POSIX message queue API
+- Attempts to create up to `QM_QUEUE_COUNT` message queues (default: 6)
+- Validates that exactly 4 queues can be created (container limit)
+- Properly handles the `ENOSPC` error when the limit is reached
+- Uses minimal queue sizes (1 message, 64 bytes) to test count limits, not memory limits
+
+### test_host_mqueue.c
+
+A C program that runs on the host system:
+
+- Creates individual message queues on the host filesystem
+- Uses same minimal queue attributes as container test
+- Demonstrates host queue creation capability independent of container limits
+
+### test.sh
+
+The main test script that:
+
+- Follows enhanced FFI test pattern with three phases
+- **Phase 1**: Creates `HOST_QUEUE_COUNT` message queues on host
+- **Phase 2**: Verifies container sysctl and runs container limit test
+- **Phase 3**: Creates `HOST_QUEUE_COUNT` additional queues on host
+- Comprehensive cleanup of both host and container artifacts
+
+## Configuration
+
+### Environment Variables
+
+- `HOST_QUEUE_COUNT`: Number of queues to create on host in each phase (default: 3)
+- `QM_QUEUE_COUNT`: Number of queues to attempt in container test (default: 6)
+
+## Expected Results
+
+- **PASS**:
+  - Host creates `HOST_QUEUE_COUNT` queues successfully (before)
+  - Container creates exactly 4 message queues then hits limit
+  - Host creates `HOST_QUEUE_COUNT` additional queues successfully (after)
+  - Total: `2 * HOST_QUEUE_COUNT` host queues + 4 container queues (isolated)
+
+- **FAIL**:
+  - Host queue creation affected by container limits
+  - Container creates more/fewer than 4 queues

--- a/tests/ffi/mqueue/main.fmf
+++ b/tests/ffi/mqueue/main.fmf
@@ -1,0 +1,27 @@
+summary: Test message queue limit enforcement in QM container and host isolation
+description: |
+    This test verifies that the fs.mqueue.queues_max=4 sysctl setting is properly
+    applied in the QM container and that the limit is enforced when creating message queues
+    while the host can create more queues.
+
+    The test will:
+    1. Create HOST_QUEUE_COUNT message queues on the host (before container test)
+    2. Verify QM container has fs.mqueue.queues_max=4 and can create exactly 4 queues
+    3. Create HOST_QUEUE_COUNT more message queues on the host (after container limit reached)
+    4. Demonstrate that host can create 2*HOST_QUEUE_COUNT total queues despite container limits
+
+    Expected results:
+        - Host message queues work independently before and after container test
+        - QM container sysctl fs.mqueue.queues_max returns 4
+        - QM container can create exactly 4 message queues then hits limit
+        - Host isolation: container limits don't affect host queue creation ability
+
+contact: Albert Esteve <aesteve@redhat.com>
+environment:
+    QM_QUEUE_COUNT: 6
+    HOST_QUEUE_COUNT: 5
+test: /bin/bash ./test.sh
+duration: 10m
+tag: ffi
+framework: shell
+id: 774b0232-e29f-4bde-bbab-766e95721965

--- a/tests/ffi/mqueue/test.sh
+++ b/tests/ffi/mqueue/test.sh
@@ -1,0 +1,168 @@
+#!/bin/bash -euvx
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# shellcheck disable=SC1091
+
+. ../common/prepare.sh
+
+# Number of host message queues to test (configurable via environment)
+HOST_QUEUE_COUNT=${HOST_QUEUE_COUNT:-3}
+
+# Validate HOST_QUEUE_COUNT is reasonable
+if ! [[ "$HOST_QUEUE_COUNT" =~ ^[1-9][0-9]*$ ]] || [ "$HOST_QUEUE_COUNT" -gt 100 ]; then
+    echo "ERROR: HOST_QUEUE_COUNT must be a positive integer between 1 and 100, got: $HOST_QUEUE_COUNT"
+    exit 1
+fi
+
+# Comprehensive cleanup function to ensure no state is left behind
+# shellcheck disable=SC2317  # Function is called indirectly via trap
+comprehensive_cleanup() {
+    info_message "Running comprehensive cleanup"
+
+    # Clean up host message queues
+    if [ -d "/dev/mqueue" ]; then
+        for mq_file in /dev/mqueue/host_test_queue_*; do
+            if [ -e "$mq_file" ]; then
+                info_message "Cleaning up leftover host message queue: $mq_file"
+                rm -f "$mq_file" 2>/dev/null || true
+            fi
+        done
+    fi
+
+    # Clean up container message queues (if container is running)
+    if podman ps --format "{{.Names}}" | grep -q "^qm$" 2>/dev/null; then
+        info_message "Cleaning up container message queues"
+        podman exec qm bash -c 'for mq in /dev/mqueue/test_queue_*; do [ -e "$mq" ] && rm -f "$mq" 2>/dev/null || true; done' 2>/dev/null || true
+    fi
+
+    # Clean up compiled binaries
+    if [ -f "./test_host_mqueue" ]; then
+        info_message "Cleaning up host compiled test program"
+        make clean 2>/dev/null || true
+    fi
+
+    # Run the original disk cleanup
+    disk_cleanup 2>/dev/null || true
+}
+
+trap comprehensive_cleanup EXIT
+prepare_test
+reload_config
+
+# Run the ffi-tools container in qm vm
+running_container_in_qm
+
+# Function to test message queues on the host system
+test_host_mqueue() {
+    local action="$1"
+    local mqueue_names=()
+    local created_count=0
+
+    info_message "Testing host message queue availability ($action container test)"
+
+    # Get current host mqueue limit
+    HOST_MQUEUE_LIMIT=$(sysctl -n fs.mqueue.queues_max)
+    info_message "Host fs.mqueue.queues_max value: $HOST_MQUEUE_LIMIT"
+
+    # Build the host test program if it doesn't exist
+    if [ ! -f "./test_host_mqueue" ]; then
+        # Install development tools if needed
+        exec_cmd "dnf install -y gcc make || true"
+
+        # Build the test program
+        info_message "Building host message queue test program"
+        make test_host_mqueue
+    fi
+
+    # Try to create message queues on the host to verify they work
+    for i in $(seq 1 "$HOST_QUEUE_COUNT"); do
+        local queue_name="/host_test_queue_${action}_$i"
+        mqueue_names+=("$queue_name")
+
+        # Clean up any existing queue first
+        if [ -e "/dev/mqueue$queue_name" ]; then
+            rm -f "/dev/mqueue$queue_name" 2>/dev/null || true
+        fi
+
+        # Use the pre-built test program
+        if ./test_host_mqueue "$queue_name"; then
+            created_count=$((created_count + 1))
+            info_message "Host queue $queue_name created successfully"
+        else
+            info_message "FAIL: Could not create host queue $queue_name"
+            return 1
+        fi
+    done
+
+    info_message "PASS: Successfully created $created_count host message queues $action container test"
+    if [ "$action" = "after" ]; then
+        local total_queues=$((HOST_QUEUE_COUNT * 2))
+        info_message "Host now has $total_queues total queues ($HOST_QUEUE_COUNT before + $HOST_QUEUE_COUNT after), demonstrating isolation from container's 4-queue limit"
+        # Don't clean up here - comprehensive_cleanup at exit will handle all host queues
+    fi
+
+    return 0
+}
+
+# Function to test the message queue limit
+test_mqueue_limit() {
+    info_message "Testing message queue limit enforcement in QM container"
+
+    # Check if the sysctl setting is applied correctly
+    MQUEUE_LIMIT=$(podman exec qm sysctl -n fs.mqueue.queues_max)
+    info_message "Current fs.mqueue.queues_max value in QM: $MQUEUE_LIMIT"
+
+    if [ "$MQUEUE_LIMIT" != "4" ]; then
+        info_message "FAIL: Expected fs.mqueue.queues_max=4, but got $MQUEUE_LIMIT"
+        exit 1
+    fi
+
+    # Install development tools if needed
+    exec_cmd "dnf install --setopt=reposdir=/etc/yum.repos.d  --installroot=/usr/lib/qm/rootfs -y gcc make || true"
+
+    # Create test directory and copy the test files to the QM container
+    exec_cmd "podman exec qm mkdir -p /tmp/mqueue_test"
+    exec_cmd "podman cp test_mqueue_limit.c qm:/tmp/mqueue_test/"
+    exec_cmd "podman cp Makefile qm:/tmp/mqueue_test/"
+
+    # Compile the test program inside QM
+    exec_cmd "podman exec qm bash -c 'cd /tmp/mqueue_test && make test_mqueue_limit'"
+
+    # Run the test program inside QM
+    if exec_cmd "podman exec qm bash -c 'cd /tmp/mqueue_test && ./test_mqueue_limit'"; then
+        info_message "PASS: Message queue limit test passed successfully"
+    else
+        info_message "FAIL: Message queue limit test failed"
+        exit 1
+    fi
+}
+
+# Execute the tests
+info_message "=== Starting message queue isolation test ==="
+
+# Test 1: Verify host message queues work before container test
+test_host_mqueue "before"
+
+# Test 2: Run the container message queue limit test
+test_mqueue_limit
+
+# Test 3: Verify host message queues still work after container test
+test_host_mqueue "after"
+
+info_message "=== All message queue tests passed successfully ==="
+
+# Clean up compiled binaries
+info_message "Cleaning up compiled test programs"
+
+exit 0

--- a/tests/ffi/mqueue/test_host_mqueue.c
+++ b/tests/ffi/mqueue/test_host_mqueue.c
@@ -1,0 +1,41 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <mqueue.h>
+#include <sys/stat.h>
+#include <errno.h>
+#include <string.h>
+
+int main(int argc, char *argv[]) {
+    if (argc != 2) {
+        fprintf(stderr, "Usage: %s <queue_name>\n", argv[0]);
+        return 1;
+    }
+
+    struct mq_attr attr;
+    attr.mq_flags = 0;
+    attr.mq_maxmsg = 1;      // Minimal: only 1 message per queue
+    attr.mq_msgsize = 64;    // Minimal: small message size
+    attr.mq_curmsgs = 0;
+
+    mqd_t mq = mq_open(argv[1], O_CREAT | O_RDWR, 0666, &attr);
+    if (mq == -1) {
+        fprintf(stderr, "Failed to create queue %s: %s\n", argv[1], strerror(errno));
+        return 1;
+    }
+
+    printf("Successfully created queue %s\n", argv[1]);
+    mq_close(mq);
+    return 0;
+}

--- a/tests/ffi/mqueue/test_mqueue_limit.c
+++ b/tests/ffi/mqueue/test_mqueue_limit.c
@@ -1,0 +1,99 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <unistd.h>
+#include <sys/stat.h>
+#include <mqueue.h>
+
+// Allow MAX_QUEUES to be set via the environment variable "QM_QUEUE_COUNT", defaulting to 6 if not set
+int get_max_queues() {
+    const char *env = getenv("QM_QUEUE_COUNT");
+    if (env) {
+        int val = atoi(env);
+        if (val > 0 && val < 1000) {
+            return val;
+        }
+    }
+    return 6;
+}
+#define MAX_QUEUES (get_max_queues())
+#define QUEUE_NAME_PREFIX "/test_queue_"
+
+int main() {
+    mqd_t queues[MAX_QUEUES];
+    char queue_names[MAX_QUEUES][32];
+    int i, created_queues = 0;
+    struct mq_attr attr;
+
+    // Initialize queue attributes (minimal to avoid memory limits)
+    attr.mq_flags = 0;
+    attr.mq_maxmsg = 1;      // Minimal: only 1 message per queue
+    attr.mq_msgsize = 64;    // Minimal: small message size
+    attr.mq_curmsgs = 0;
+
+    printf("Testing message queue limit enforcement...\n");
+
+    // Clean up any existing queues from previous runs
+    for (i = 0; i < MAX_QUEUES; i++) {
+        snprintf(queue_names[i], sizeof(queue_names[i]), "%s%d", QUEUE_NAME_PREFIX, i);
+        mq_unlink(queue_names[i]);
+    }
+
+    // Try to create message queues
+    for (i = 0; i < MAX_QUEUES; i++) {
+        printf("Attempting to create queue %s... ", queue_names[i]);
+
+        queues[i] = mq_open(queue_names[i], O_CREAT | O_RDWR, 0666, &attr);
+
+        if (queues[i] == -1) {
+            printf("FAILED: %s\n", strerror(errno));
+            if (errno == ENOSPC) {
+                printf("Queue limit reached as expected at queue %d\n", i);
+                break;
+            } else {
+                printf("Unexpected error: %s\n", strerror(errno));
+                // Clean up before exiting
+                for (int j = 0; j < i; j++) {
+                    mq_close(queues[j]);
+                    mq_unlink(queue_names[j]);
+                }
+                return 1;
+            }
+        } else {
+            printf("SUCCESS\n");
+            created_queues++;
+        }
+    }
+
+    printf("\nSuccessfully created %d message queues\n", created_queues);
+
+    // Expected behavior: should be able to create exactly 4 queues
+    if (created_queues == 4) {
+        printf("PASS: Created exactly 4 queues as expected (limit is working)\n");
+    } else if (created_queues < 4) {
+        printf("FAIL: Created fewer than 4 queues (%d), limit may be too restrictive\n", created_queues);
+    } else {
+        printf("FAIL: Created more than 4 queues (%d), limit is not enforced properly\n", created_queues);
+    }
+
+    // Clean up created queues
+    for (i = 0; i < created_queues; i++) {
+        mq_close(queues[i]);
+        mq_unlink(queue_names[i]);
+    }
+
+    return (created_queues == 4) ? 0 : 1;
+}


### PR DESCRIPTION
Limit the max number of message queues to 4.
Create a test to verify this setting.

Fixes: https://github.com/containers/qm/issues/873

## Summary by Sourcery

Enforce a maximum of 4 POSIX message queues in the QM container and add a comprehensive FFI test to verify the setting and its enforcement

New Features:
- Set fs.mqueue.queues_max sysctl in the QM container to limit message queues to 4

Documentation:
- Add a README describing the purpose and steps of the message queue limit test

Tests:
- Add a C test program and shell script to validate the sysctl value and enforce the 4-queue limit
- Include a Makefile and FMF metadata for building and running the message queue limit test