### PR TITLE
Add OCI hooks for Wayland devices configuration

### DIFF
--- a/oci-hooks/wayland-client-devices/README.md
+++ b/oci-hooks/wayland-client-devices/README.md
@@ -1,0 +1,39 @@
+# Wayland-client-devices
+
+The wayland-client-devices OCI hook enables containers to access GPU hardware acceleration devices for Wayland client
+applications that would run as qm's nested containers.
+
+## Key Functionality
+
+1. **GPU Device Discovery**: The hook automatically discovers and configures access to GPU render devices when
+   GPU support is enabled, including:
+
+   - GPU hardware acceleration devices
+
+2. **Container Configuration**: It dynamically modifies the container's OCI configuration to include the necessary
+   GPU device permissions and access controls for Wayland client applications that require hardware acceleration.
+
+## Configuration
+
+The hook supports the following container annotation:
+
+- `org.containers.qm.wayland-client.gpu`: Enables GPU device access for Wayland clients. When this annotation is
+  present, the hook will automatically detect and configure access to available render devices in `/dev/dri/`.
+
+## Example Configuration
+
+To use the Wayland-client-devices hook, you can create a dropin configuration file to add the necessary annotation
+to your container:
+
+1. Create a dropin directory and file:
+
+   ```bash
+   mkdir -p /etc/containers/systemd/myapp.container.d/
+   ```
+
+2. Create a dropin file (e.g., `wayland-client.conf`):
+
+   ```ini
+   [Container]
+   Annotation=org.containers.qm.wayland-client.gpu=true
+   ```

--- a/oci-hooks/wayland-client-devices/oci-qm-wayland-client-devices
+++ b/oci-hooks/wayland-client-devices/oci-qm-wayland-client-devices
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+input="-"
+CONTAINER_CONFIG=$(cat "$input")
+
+GPU_ENABLED=$(echo "$CONTAINER_CONFIG" | jq -r '.annotations["org.containers.qm.wayland-client.gpu"] // empty')
+
+DEVNAME_LIST=()
+
+if [ -n "$GPU_ENABLED" ]; then
+    # Find all the render devices available
+    RENDER_DEVICES=$(find /dev/dri -type c \( -regex ".*/render.*" \))
+    for RENDER_DEVICE in $RENDER_DEVICES; do
+        DEVNAME_LIST+=("$RENDER_DEVICE")
+    done
+fi
+
+# Iterate over the DEVNAME_LIST to include the required information in the CONTAINER_CONFIG
+for DEVICE in "${DEVNAME_LIST[@]}"; do
+    if ! jq -e ".linux.devices[] | select(.path == \"$DEVICE\")" <<< "$CONTAINER_CONFIG" > /dev/null 2>&1; then
+        # shellcheck disable=SC2012
+        NEW_DEVICE=$(jq -n --arg path "$DEVICE"                                      \
+                           --arg dev_type "$(ls -l "$DEVICE" | head -c 1)"           \
+                           --arg major "$(printf "%d" "$(stat -c "%#t" "$DEVICE")")"      \
+                           --arg minor "$(printf "%d" "$(stat -c "%#T" "$DEVICE")")"      \
+                           --arg filemode "$(printf "%d" "$(stat -c '02%#a' "$DEVICE")")" \
+                           --arg uid "$(stat -c "%u" "$DEVICE")"                       \
+                           --arg gid "$(stat -c "%g" "$DEVICE")"                       \
+                        '{
+                            "path": $path,
+                            "type": $dev_type,
+                            "major": $major|tonumber,
+                            "minor": $minor|tonumber,
+                            "fileMode": $filemode|tonumber,
+                            "uid": $uid|tonumber,
+                            "gid": $gid|tonumber,
+                        }')
+
+        # shellcheck disable=SC2012
+        NEW_DEV_RESOURCE=$(jq -n                                                \
+                           --arg dev_type "$(ls -l "$DEVICE" | head -c 1)"      \
+                           --arg major "$(printf "%d" "$(stat -c "%#t" "$DEVICE")")" \
+                           --arg minor "$(printf "%d" "$(stat -c "%#T" "$DEVICE")")" \
+                        '{
+                            "allow": true,
+                            "type": $dev_type,
+                            "major": $major|tonumber,
+                            "minor": $minor|tonumber,
+                            "access": "rwm"
+                        }')
+
+        CONTAINER_CONFIG=$(jq ".linux.devices += [$NEW_DEVICE]" <<< "$CONTAINER_CONFIG")
+        CONTAINER_CONFIG=$(jq ".linux.resources.devices += [$NEW_DEV_RESOURCE]" <<< "$CONTAINER_CONFIG")
+    fi
+done
+
+echo "$CONTAINER_CONFIG" | jq .
+

--- a/oci-hooks/wayland-client-devices/oci-qm-wayland-client-devices.json
+++ b/oci-hooks/wayland-client-devices/oci-qm-wayland-client-devices.json
@@ -1,0 +1,12 @@
+{
+  "version": "1.0.0",
+  "hook": {
+    "path": "/usr/libexec/oci/hooks.d/oci-qm-wayland-client-devices"
+  },
+  "when": {
+    "annotations": {
+      "^org\\.containers\\.qm\\.wayland-client\\..*$": "^.*$"
+    }
+  },
+  "stages": ["precreate"]
+}

--- a/oci-hooks/wayland-session-devices/README.md
+++ b/oci-hooks/wayland-session-devices/README.md
@@ -1,0 +1,46 @@
+# Wayland-session-devices
+
+The wayland-session-devices OCI hook enables containers to access Wayland display server devices in a multi-seat
+environment managed by systemd-logind.
+
+## Key Functionality
+
+1. **Device Discovery**: The hook automatically discovers and configures access to hardware devices associated with a
+   specific systemd-logind seat, including:
+
+   - Input devices (keyboard, mouse, touchpad, etc.)
+   - Render devices (GPU hardware acceleration)
+   - Display-related devices
+
+2. **Container Configuration**: It dynamically modifies the container's OCI configuration to include the necessary
+   device permissions and access controls for Wayland compositor functionality.
+
+## Configuration
+
+The hook supports the following container annotation:
+
+- `org.containers.qm.wayland.seat`: Specifies which systemd-logind seat devices should be made available to the
+  container. This annotation would be used in the QM container and the wayland compositor container
+  (running as a nested container inside the QM container) to have access to the required devices.
+  The value should match a valid seat name configured in the system's multi-seat infrastructure.
+
+## Example Configuration
+
+To use the Wayland-session-devices hook, you can create a dropin configuration file to add the necessary annotation
+to your qm.container:
+
+1. Create a dropin directory and file:
+
+   ```bash
+   mkdir -p /etc/containers/systemd/qm.container.d/
+   ```
+
+2. Create a dropin file (e.g., `wayland.conf`):
+
+   ```ini
+   [Container]
+   Annotation=org.containers.qm.wayland.seat=seat0
+   ```
+
+The same procedure would be done in the wayland compositor container, running inside the qm container as nested
+container, by adding a similar dropin file.

--- a/oci-hooks/wayland-session-devices/oci-qm-wayland-session-devices
+++ b/oci-hooks/wayland-session-devices/oci-qm-wayland-session-devices
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+input="-"
+CONTAINER_CONFIG=$(cat "$input")
+
+SEAT=$(echo "$CONTAINER_CONFIG" | jq -r '.annotations["org.containers.qm.wayland.seat"] // empty')
+
+DEVNAME_LIST=()
+
+if [ -n "$SEAT" ]; then
+    # Extract and resolve all the devices associated to a systemd-logind seat
+    SEAT_SYS_DEVICE_LIST=$(loginctl seat-status "$SEAT" | grep -oP '/sys\S+')
+
+    for DEVICE in $SEAT_SYS_DEVICE_LIST; do
+        DEVNAME=$(udevadm info -x "$DEVICE" | grep -oP '^E: DEVNAME=\K.*')
+
+        if [ -n "$DEVNAME" ]; then
+            DEVNAME_LIST+=("$DEVNAME")
+        fi
+    done
+
+    # Find all the input devices available
+    INPUT_DEVICES=$(find /dev/input -type c \( -regex ".*/event[0-9]+" -o -regex ".*/mice[0-9]*" -o -regex ".*/mouse[0-9]+" \))
+    for INPUT_DEVICE in $INPUT_DEVICES; do
+        DEVNAME_LIST+=("$INPUT_DEVICE")
+    done
+
+    # Find all the render devices available
+    RENDER_DEVICES=$(find /dev/dri -type c \( -regex ".*/render.*" \))
+    for RENDER_DEVICE in $RENDER_DEVICES; do
+        DEVNAME_LIST+=("$RENDER_DEVICE")
+    done
+
+    # Check if .linux.devices exists and is a list in $CONTAINER_CONFIG
+    if ! jq -e '.linux.devices | arrays' <<< "$CONTAINER_CONFIG" > /dev/null 2>&1; then
+        # Create an empty .linux.devices list if it does not exist
+        CONTAINER_CONFIG=$(jq '.linux.devices = []' <<< "$CONTAINER_CONFIG")
+    fi
+
+    # Iterate over the DEVNAME_LIST to include the required information in the CONTAINER_CONFIG
+    for DEVICE in "${DEVNAME_LIST[@]}"; do
+        if ! jq -e ".linux.devices[] | select(.path == \"$DEVICE\")" <<< "$CONTAINER_CONFIG" > /dev/null 2>&1; then
+            # shellcheck disable=SC2012
+            NEW_DEVICE=$(jq -n --arg path "$DEVICE"                                      \
+                               --arg dev_type "$(ls -l "$DEVICE" | head -c 1)"           \
+                               --arg major "$(printf "%d" "$(stat -c "%#t" "$DEVICE")")"      \
+                               --arg minor "$(printf "%d" "$(stat -c "%#T" "$DEVICE")")"      \
+                               --arg filemode "$(printf "%d" "$(stat -c '02%#a' "$DEVICE")")" \
+                               --arg uid "$(stat -c "%u" "$DEVICE")"                       \
+                               --arg gid "$(stat -c "%g" "$DEVICE")"                       \
+                            '{
+                                "path": $path,
+                                "type": $dev_type,
+                                "major": $major|tonumber,
+                                "minor": $minor|tonumber,
+                                "fileMode": $filemode|tonumber,
+                                "uid": $uid|tonumber,
+                                "gid": $gid|tonumber,
+                            }')
+
+            # shellcheck disable=SC2012
+            NEW_DEV_RESOURCE=$(jq -n                                                \
+                               --arg dev_type "$(ls -l "$DEVICE" | head -c 1)"      \
+                               --arg major "$(printf "%d" "$(stat -c "%#t" "$DEVICE")")" \
+                               --arg minor "$(printf "%d" "$(stat -c "%#T" "$DEVICE")")" \
+                            '{
+                                "allow": true,
+                                "type": $dev_type,
+                                "major": $major|tonumber,
+                                "minor": $minor|tonumber,
+                                "access": "rwm"
+                            }')
+
+            CONTAINER_CONFIG=$(jq ".linux.devices += [$NEW_DEVICE]" <<< "$CONTAINER_CONFIG")
+            CONTAINER_CONFIG=$(jq ".linux.resources.devices += [$NEW_DEV_RESOURCE]" <<< "$CONTAINER_CONFIG")
+        fi
+    done
+fi
+
+echo "$CONTAINER_CONFIG" | jq .

--- a/oci-hooks/wayland-session-devices/oci-qm-wayland-session-devices.json
+++ b/oci-hooks/wayland-session-devices/oci-qm-wayland-session-devices.json
@@ -1,0 +1,12 @@
+{
+  "version": "1.0.0",
+  "hook": {
+    "path": "/usr/libexec/oci/hooks.d/oci-qm-wayland-session-devices"
+  },
+  "when": {
+    "annotations": {
+      "^org\\.containers\\.qm\\.wayland\\..*$": "^.*$"
+    }
+  },
+  "stages": ["precreate"]
+}


### PR DESCRIPTION
Fix #882 

- Implemented `oci-qm-wayland-session-devices` hook for managing seat-specific device access in multi-seat environments.
- Implemented `oci-qm-wayland-client-devices` hook for enabling GPU hardware acceleration for Wayland clients.
- Added documentation for configuration and usage.

## Summary by Sourcery

Add two OCI hooks for Wayland device access, and document their configuration and usage

New Features:
- Introduce oci-qm-wayland-session-devices hook for granting containers access to systemd-logind seat-specific input, render, and display devices
- Introduce oci-qm-wayland-client-devices hook for enabling GPU hardware acceleration for Wayland client applications

Documentation:
- Add user-facing documentation in README.md detailing configuration and example usage for both OCI hooks

## Summary by Sourcery

Introduce two OCI hooks for Wayland device management—one for multi-seat session devices and another for GPU acceleration in Wayland clients—and provide user-facing documentation for their configuration and usage

New Features:
- Add oci-qm-wayland-session-devices hook to grant containers access to systemd-logind seat-specific input, render, and display devices
- Add oci-qm-wayland-client-devices hook to enable GPU hardware acceleration for Wayland client applications

Documentation:
- Document configuration and usage examples for both OCI hooks in README.md