### PR TITLE
Qm 0.7.4.z

### DIFF
--- a/create-seccomp-rules
+++ b/create-seccomp-rules
@@ -37,11 +37,69 @@ function add_syscall_deny_list() {
     local syscall_name="$1"
     local seccomp_file_path="$2"
 
+    local temp_file
     temp_file=$(mktemp)
-    jq --tab \
-       --arg syscall "$syscall_name" \
-       '.syscalls += [{"names": [$syscall], "action": "SCMP_ACT_ERRNO", "args": [], "errnoRet": 1, "errno": "EPERM"}]' \
-       "${seccomp_file_path}" > "$temp_file" && mv "$temp_file" "${seccomp_file_path}"
+
+    if [[ "$syscall_name" == "sched_setscheduler" ]]; then
+        jq --tab \
+           '.syscalls += [
+               {
+                   "names": ["sched_setscheduler"],
+                   "action": "SCMP_ACT_ALLOW",
+                   "args": [
+                       {
+                           "index": 1,
+                           "value": 0,
+                           "valueTwo": 0,
+                           "op": "SCMP_CMP_EQ"
+                       }
+                   ],
+                   "comment": "",
+                   "includes": {},
+                   "excludes": {}
+               },
+               {
+                   "names": ["sched_setscheduler"],
+                   "action": "SCMP_ACT_ALLOW",
+                   "args": [
+                       {
+                           "index": 1,
+                           "value": 3,
+                           "valueTwo": 0,
+                           "op": "SCMP_CMP_EQ"
+                       }
+                   ],
+                   "comment": "",
+                   "includes": {},
+                   "excludes": {}
+               },
+               {
+                   "names": ["sched_setscheduler"],
+                   "action": "SCMP_ACT_ALLOW",
+                   "args": [
+                       {
+                           "index": 1,
+                           "value": 5,
+                           "valueTwo": 0,
+                           "op": "SCMP_CMP_EQ"
+                       }
+                   ],
+                   "comment": "",
+                   "includes": {},
+                   "excludes": {}
+               }
+           ]' "$seccomp_file_path" > "$temp_file" && mv "$temp_file" "$seccomp_file_path"
+    else
+        jq --tab \
+           --arg syscall "$syscall_name" \
+           '.syscalls += [{
+               "names": [$syscall],
+               "action": "SCMP_ACT_ERRNO",
+               "args": [],
+               "errnoRet": 1,
+               "errno": "EPERM"
+           }]' "$seccomp_file_path" > "$temp_file" && mv "$temp_file" "$seccomp_file_path"
+    fi
 
     rm "$temp_file" &> /dev/null
 }

--- a/plans/e2e/ffi.fmf
+++ b/plans/e2e/ffi.fmf
@@ -24,6 +24,10 @@ adjust:
         script: |
            cd tests/e2e
            ./set-ffi-env-e2e "${FFI_SETUP_OPTIONS}"
+      - name: Place quadlet for ffi-qm container
+        how: shell
+        script: |
+            cp tests/ffi/common/ffi-qm.container /etc/qm/containers/systemd/
 
 execute:
     how: tmt

--- a/tests/ffi/agent-flood/test.sh
+++ b/tests/ffi/agent-flood/test.sh
@@ -79,8 +79,9 @@ get_qm_network_mode(){
     echo "${qm_network_mode}"
 }
 
-init_ffi
-prepare_images
+trap disk_cleanup EXIT
+prepare_test
+reload_config
 
 # Assign value to ${controller_host_ip} according to qm network mode
 if [ "$(get_qm_network_mode)" == "private" ]; then

--- a/tests/ffi/common/ffi-qm.container
+++ b/tests/ffi/common/ffi-qm.container
@@ -1,0 +1,15 @@
+[Unit]
+Description=Container ffi-tools with precompiled checks
+After=local-fs.target
+
+[Container]
+ContainerName=ffi-qm
+Image=quay.io/centos-sig-automotive/ffi-tools:latest
+Exec=sleep infinity
+
+[Install]
+# Start by default on qm boot
+WantedBy=multi-user.target default.target
+
+[Service]
+Restart=always

--- a/tests/ffi/common/prepare.sh
+++ b/tests/ffi/common/prepare.sh
@@ -2,13 +2,8 @@
 # shellcheck disable=SC1091
 . ../../e2e/lib/utils
 
-DROP_IN_DIR="/etc/containers/systemd/qm.container.d/"
+export DROP_IN_DIR="/etc/containers/systemd/qm.container.d/"
 OSTREE_PATH="/run/ostree"
-export QM_HOST_REGISTRY_DIR="/var/qm/lib/containers/registry"
-export QM_REGISTRY_DIR="/var/lib/containers/registry"
-export QM_TMP_DIR="/var/tmp.dir"
-export CONTAINERS_CONF_DIR="/etc/qm/containers/containers.conf.d"
-export QM_IMAGE_TMP_DIR_CONF="qm_image_tmp_dir.conf"
 
 # Checks if the system is running under OSTree.
 # This function determines if the system is using OSTree by checking for the
@@ -38,12 +33,12 @@ prepare_test() {
 }
 
 disk_cleanup() {
-   exec_cmd "podman exec -it qm /bin/bash -c \"podman  rmi -f --all\""
    # Clean large size files created by tests inside qm part
    remove_file=$(find /var/qm -size  +2G)
    exec_cmd "rm -rf $remove_file"
-   # Clean drop-in files used for tests
-   if test -d "${DROP_IN_DIR=}"; then
+   # Remove all containers in qm (don't care about stop in clean-up)
+   exec_cmd "podman exec -it qm /usr/bin/podman rm -af"
+   if test -d "${DROP_IN_DIR}"; then
       exec_cmd "rm -rf ${DROP_IN_DIR}"
    fi
    exec_cmd "systemctl daemon-reload"
@@ -58,60 +53,13 @@ reload_config() {
    exec_cmd "systemctl restart qm"
 }
 
-prepare_images() {
-   # Update container image_copy_tmp_dir if the image is an OStree.
-   # Default location for storing temporary container image content. Can be overridden with the TMPDIR environment
-   # variable. If you specify "storage", then the location of the
-   # container/storage tmp directory will be used.
-   # By default image_copy_tmp_dir="/var/tmp"
-   # This is a work around and it should not be used constantly
-   # This script checks if the directory /run/ostree exists.
-   # If it does, it executes the following commands:
-   # 1. Creates the directory /var/qm/tmp.dir if it does not already exist.
-   # 2. Creates the directory /etc/qm/containers/containers.conf.d if it does not already exist.
-   # 3. Writes a configuration file qm_image_tmp_dir.conf in /etc/qm/containers/containers.conf.d
-   #    with the content specifying the temporary directory for image copying as /var/tmp.dir.
-
-   if is_ostree; then
-      exec_cmd "mkdir -p /var/qm/tmp.dir"
-      exec_cmd "mkdir -p ${CONTAINERS_CONF_DIR}"
-      exec_cmd "echo -e '[engine]\nimage_copy_tmp_dir=\"${QM_TMP_DIR}\"' > ${CONTAINERS_CONF_DIR}/${QM_IMAGE_TMP_DIR_CONF}"
-   fi
-
-   exec_cmd "podman pull quay.io/centos-sig-automotive/ffi-tools:latest"
-   # Copy container image registry to /var/qm/lib/containers
-   image_id=$(podman images | grep quay.io/centos-sig-automotive/ffi-tools | awk -F " " '{print $3}')
-
-   if [ -d "${QM_HOST_REGISTRY_DIR}" ]; then
-      rm -rf ${QM_HOST_REGISTRY_DIR}
-   fi
-
-   exec_cmd "mkdir -p ${QM_HOST_REGISTRY_DIR}"
-   exec_cmd "podman push ${image_id} dir:${QM_HOST_REGISTRY_DIR}/tools-ffi:latest"
-   # Remove image to save /var space
-   exec_cmd "podman rmi -f ${image_id}"
-}
-
-run_container_in_qm() {
-   local container_name
-   local tmp_image_dir
-   local run_ctr_in_qm
-   # Clean tmp image directory
-   tmp_image_dir=$(podman info | grep  CopyTmp | awk -F":" '{print $2}')
-   container_name="${1}"
-
-   exec_cmd "podman exec -it qm /bin/bash -c \
-      \"rm -rf ${tmp_image_dir}/*\""
-   run_ctr_in_qm="podman exec -it qm /bin/bash -c \
-      \"podman run -d --net host  --replace --name ${container_name} \
-      dir:${QM_REGISTRY_DIR}/tools-ffi:latest \
-      tail -f /dev/null\""
-   exec_cmd "${run_ctr_in_qm}"
-}
-
-# Agregates 3 functions from this tool to a single init_ffi function, used to initialize environments before tests with a single function, instead of using three separate functions.
-init_ffi() {
-        disk_cleanup
-        prepare_test
-        reload_config
+running_container_in_qm() {
+     while true; do
+         if podman exec qm /usr/bin/systemctl is-active ffi-qm -q; then
+             info_message "ffi-qm container inside qm is fully started"
+             break
+         fi
+         sleep 1
+     done
+     info_message "qm was started: $(systemctl status qm | grep Active | cut -d ';' -f 2)"
 }

--- a/tests/ffi/deny_sched_setattr/test.sh
+++ b/tests/ffi/deny_sched_setattr/test.sh
@@ -5,20 +5,18 @@
 
 expected_result="sched_setattr failed: Operation not permitted"
 
-disk_cleanup
+trap disk_cleanup EXIT
 prepare_test
 reload_config
 
-prepare_images
-run_container_in_qm "ffi-qm"
+running_container_in_qm
 
-return_from_sched_setattr=$(podman exec -it qm /bin/bash -c \
-         'podman exec -it ffi-qm ./QM/execute_sched_setattr')
+return_from_sched_setattr=$(podman exec -it qm /usr/bin/podman exec -it ffi-qm ./QM/execute_sched_setattr)
 
 # shellcheck disable=SC2076
 if [[ "${return_from_sched_setattr}" =~ "${expected_result}" ]]; then
-    info_message "QM not allow SCHED_DEADLINE be set via sched_setattr() syscall."
+    info_message "PASS: QM not allow SCHED_DEADLINE be set via sched_setattr() syscall."
 else
-    info_message "Failure: SCHED_DEADLINE can not be set via sched_setattr() syscall in QM."
+    info_message "FAIL: SCHED_DEADLINE can not be set via sched_setattr() syscall in QM."
     exit 1
 fi

--- a/tests/ffi/deny_set_scheduler/test.sh
+++ b/tests/ffi/deny_set_scheduler/test.sh
@@ -3,7 +3,7 @@
 # shellcheck source=tests/ffi/common/prepare.sh
 . ../common/prepare.sh
 
-expected_result="Failed to set scheduler: Operation not permitted"
+expected_result="Failed to set scheduler: Function not implemented"
 
 disk_cleanup
 prepare_test

--- a/tests/ffi/deny_set_scheduler/test.sh
+++ b/tests/ffi/deny_set_scheduler/test.sh
@@ -3,21 +3,44 @@
 # shellcheck source=tests/ffi/common/prepare.sh
 . ../common/prepare.sh
 
-expected_result="Failed to set scheduler: Function not implemented"
+policy_arr=(SCHED_OTHER SCHED_BATCH SCHED_IDLE SCHED_FIFO SCHED_RR)
+num_of_failed_policy=0
 
-disk_cleanup
+trap disk_cleanup EXIT
 prepare_test
 reload_config
 
-prepare_images
-run_container_in_qm "ffi-qm"
+running_container_in_qm
+# Copy the test from ffi-qm container to qm container
+podman exec -it qm /usr/bin/podman cp ffi-qm:/root/tests/FFI/bin/QM/test_sched_setscheduler /var/
 
-return_from_setscheduler=$(podman exec -it qm /bin/bash -c \
-         'podman exec -it ffi-qm ./QM/test_sched_setscheduler')
+for policy in "${policy_arr[@]}"; do
+    # Run the test inside qm container
+    return_from_setscheduler=$(podman exec -it qm ./var/test_sched_setscheduler "$policy")
 
-if [[ "${return_from_setscheduler}" =~ ${expected_result} ]]; then
-    info_message "set_scheduler() syscall denied in QM."
-else
-    info_message "set_scheduler() syscall can be executed in QM."
+    # Assign the expected result according to the policy
+    if [[ "$policy" == "SCHED_OTHER" || "$policy" == "SCHED_BATCH" || "$policy" == "SCHED_IDLE" ]]; then
+        expected_result="sched_setscheduler($policy) succeeded."
+    elif [[ "$policy" == "SCHED_FIFO" || "$policy" == "SCHED_RR" ]]; then
+        expected_result="sched_setscheduler($policy) failed: errno=38 (Function not implemented)"
+    fi
+
+    # Check that the result is the same as expected
+    if [[ "${return_from_setscheduler}" == "${expected_result}" ]]; then
+        info_message "$expected_result"
+        info_message "PASS: The result of sched_setscheduler($policy) is as expected in QM."
+    else
+        info_message "$return_from_setscheduler"
+        info_message "FAIL: The result of sched_setscheduler($policy) is not what is expected in QM."
+        ((num_of_failed_policy++))
+    fi
+done
+
+# If there is a failed policy, then this test returns failure
+if [[ $num_of_failed_policy -gt 0 ]]; then
+    info_message "FAIL: sched_setscheduler() test failed."
     exit 1
+else
+    info_message "PASS: sched_setscheduler() test passed."
+    exit 0
 fi

--- a/tests/ffi/disk/main.fmf
+++ b/tests/ffi/disk/main.fmf
@@ -1,4 +1,4 @@
-summary: Test is calling systemd as stand alone test
+summary: Test for separate var partition for qm
 test: /bin/bash ./test.sh
 duration: 10m
 tag: [ffi, NoRenesas]

--- a/tests/ffi/main.fmf
+++ b/tests/ffi/main.fmf
@@ -6,3 +6,4 @@ require:
     pattern:
       - /tests/e2e/lib/utils
       - /tests/ffi/common/prepare.sh
+      - /tests/ffi/common/ffi-qm.container

--- a/tests/ffi/memory/main.fmf
+++ b/tests/ffi/memory/main.fmf
@@ -1,4 +1,4 @@
-summary: Test is calling systemd as stand alone test
+summary: Test to show inside containers is killed fisrt in case of OOM
 test: /bin/bash ./test.sh
 duration: 25m
 tag: ffi

--- a/tests/ffi/memory/test.sh
+++ b/tests/ffi/memory/test.sh
@@ -4,27 +4,19 @@
 
 . ../common/prepare.sh
 
-disk_cleanup
+trap disk_cleanup EXIT
 prepare_test
-
-cat << EOF > "${DROP_IN_DIR}"/oom.conf
-[Service]
-OOMScoreAdjust=
-OOMScoreAdjust=1000
-EOF
-
-reload_config
-prepare_images
 
 exec_cmd "podman run -d --rm --replace -d --name ffi-asil \
           quay.io/centos-sig-automotive/ffi-tools:latest \
           ./ASIL/20_percent_memory_eat > /dev/null"
 
-podman exec -it qm /bin/bash -c \
-         "podman run  --replace --name ffi-qm  dir:${QM_REGISTRY_DIR}/tools-ffi:latest \
-         ./QM/90_percent_memory_eat > /dev/null"
+reload_config
+running_container_in_qm
+
+podman exec qm podman exec ffi-qm ./QM/90_percent_memory_eat > /dev/null
 
 if [ $? -eq 137 ]; then
-    echo ffi-qm was killed by SIGKILL
+    info_message "ffi-qm was killed by SIGKILL"
 fi
 exec_cmd "systemctl status qm --no-pager | grep \"qm.service: A process of this unit has been killed\""

--- a/tests/ffi/modules/test.sh
+++ b/tests/ffi/modules/test.sh
@@ -1,22 +1,18 @@
-#!/bin/bash -euvx
+#!/bin/bash -uvx
 
 # shellcheck disable=SC1091
 
 . ../common/prepare.sh
 
-disk_cleanup
+trap disk_cleanup EXIT
 prepare_test
 reload_config
 
-# Download ffi-tools container and push ffi-tools image into QM registry
-prepare_images
-
 # Run the ffi-tools container in qm vm
-run_container_in_qm ffi-qm
+running_container_in_qm
 
 # Get result message of './modprobe_module'
-msg=$(podman exec -it qm /bin/bash -c \
-               "podman exec ffi-qm ./modprobe_module 2>&1")
+msg=$(podman exec -it qm /usr/bin/podman exec -it ffi-qm ./modprobe_module 2>&1)
 
 # Check result message displays right.
 if grep -eq "modprobe: FATAL: Module ext4 not found in directory /lib/modules/*" "$msg"; then

--- a/tests/ffi/qm-oom-score-adj/test.sh
+++ b/tests/ffi/qm-oom-score-adj/test.sh
@@ -16,10 +16,9 @@
 
 . ../common/prepare.sh
 
-disk_cleanup
+trap disk_cleanup EXIT
 prepare_test
 reload_config
-prepare_images
 
 # Function to retrieve the PID with retries for a container
 get_pid_with_retries() {
@@ -54,8 +53,7 @@ get_oom_score_adj() {
 }
 
 # Start the FFI container inside qm
-podman exec -it qm /bin/bash -c \
-    "podman run -d --replace --name ffi-qm dir:${QM_REGISTRY_DIR}/tools-ffi:latest /usr/bin/sleep infinity > /dev/null"
+running_container_in_qm
 
 # Check if ffi-qm container started successfully
 QM_FFI_STATUS=$(podman exec -it qm /bin/bash -c "podman inspect ffi-qm --format '{{.State.Status}}'" | tr -d '\r')

--- a/tests/ffi/qm_nested/test.sh
+++ b/tests/ffi/qm_nested/test.sh
@@ -3,8 +3,9 @@
 # shellcheck disable=SC1091
 . ../common/prepare.sh
 
-# init_ffi uses 3in1 function from common.sh to initialize the environment before tests.
-init_ffi
+trap disk_cleanup EXIT
+prepare_test
+reload_config
 
 # Declare global variables and initialize to "".
 NESTED_NAME=""
@@ -17,9 +18,8 @@ NESTED_STATUS=""
 #  NESTED_NAME: The nested container name in the QM container.
 #  NESTED_STATUS: The nested container status in the QM container.
 create_nested() {
-	prepare_images
 	local nested_container_name="ffi-qm"
-	run_container_in_qm "${nested_container_name}"
+	running_container_in_qm
 	NESTED_NAME=$(podman exec -it qm bash -c "podman inspect ${nested_container_name} --format '{{.Name}}'")
 	if_error_exit "An error occured: failed to extract Name parameter of container from inside of QM."
 	echo "Container name is: ${NESTED_NAME}"

--- a/tests/ffi/sysctl/test.sh
+++ b/tests/ffi/sysctl/test.sh
@@ -4,19 +4,15 @@
 
 . ../common/prepare.sh
 
-disk_cleanup
+trap disk_cleanup EXIT
 prepare_test
 reload_config
 
-# Download ffi-tools container and push ffi-tools image into QM registry
-prepare_images
-
 # Run the ffi-tools container in qm vm
-run_container_in_qm ffi-qm
+running_container_in_qm
 
 # Get numbers of sysctl permission denied
-sysctl_num=$(podman exec qm /bin/bash -c \
-               "podman exec ffi-qm ./setsysctl 2>&1" | grep -c "sysctl: permission denied on key")
+sysctl_num=$(podman exec qm /usr/bin/podman exec ffi-qm ./setsysctl 2>&1 | grep -c "sysctl: permission denied on key")
 
 # We execute 'X' sysctl call(s) inside a nested container running in a QM environment
 # to determine if changes are allowed, which should be denied for:
@@ -24,6 +20,6 @@ sysctl_num=$(podman exec qm /bin/bash -c \
 #  - Virtual memory subsystem
 SYSCTL_DENIED_COUNT=5
 if [ "$sysctl_num" -eq "${SYSCTL_DENIED_COUNT}" ];then
-   info_message "Attempt to change OS level are denied successfully inside QM container."
+   info_message "PASS: Attempt to change OS level are denied successfully inside QM container."
    exit 0
 fi


### PR DESCRIPTION
## Summary by Sourcery

Refactor FFI test framework by consolidating container startup and cleanup logic, removing outdated image preparation, and enhancing test scripts for robustness and clarity

New Features:
- Allow execute_set_scheduler tool to accept scheduling policy names as arguments
- Iterate over all scheduling policies in scheduler denial test and validate expected outcomes

Enhancements:
- Export DROP_IN_DIR in common prepare.sh and replace image pull/push routines with a unified running_container_in_qm function that waits for QM service startup
- Use traps to ensure disk_cleanup runs on exit and replace podman rmi calls with podman rm -af for cleaner teardown
- Normalize podman invocations with full paths and tighten shell options across test scripts
- Update disk partition checks to reference /var/qm paths

Tests:
- Remove prepare_images and run_container_in_qm from individual tests and switch to running_container_in_qm
- Streamline test flow by reloading QM configuration before running nested and memory tests
- Improve PASS/FAIL messages and exit codes in all FFI test scripts