### PR TITLE
tests: add qm-ipc tests

### DIFF
--- a/tests/qm-ipc/main.fmf
+++ b/tests/qm-ipc/main.fmf
@@ -1,0 +1,7 @@
+summary: Test plan for qm ipc
+test: ./test_ipc.sh
+duration: 10m
+tag: qm-ipc
+tier: 0
+framework: shell
+id: b1e2c318-84bd-4119-8e10-ff4bc7cd31f4

--- a/tests/qm-ipc/scripts/asil-to-qm/asil-to-qm.sh
+++ b/tests/qm-ipc/scripts/asil-to-qm/asil-to-qm.sh
@@ -1,0 +1,214 @@
+#!/bin/bash
+
+daemon_reload_in_qm() {
+    echo "qm: systemctl daemon-reload inside qm..."
+    podman exec -it qm bash -c "systemctl daemon-reload"
+}
+
+restart_ipc_client_in_qm() {
+    echo "qm: restart ipc_client inside qm..."
+    podman exec -it qm bash -c "podman restart systemd-ipc_client"
+    sleep 15
+}
+
+show_qm_podman_ps() {
+    echo "qm: podman ps inside qm..."
+    podman exec -it qm bash -c "podman ps"
+}
+
+check_ipc_client_logs() {
+    echo "qm: podman logs systemd-ipc_client"
+    if podman exec -it qm bash -c "podman logs systemd-ipc_client" | grep -Eiq "permission denied|no such file or directory"; then
+        echo "systemd-ipc_client has failed"
+        exit 1
+    fi
+}
+
+check_nested_container_exists() {
+  local container_name="$1"
+
+  echo "Checking for '$container_name' inside 'qm'..."
+
+  # Capture output of nested podman ps inside qm
+  local output
+  output=$(podman exec qm podman ps --format "{{.Names}}" 2>/dev/null)
+
+  if echo "$output" | grep -wq "$container_name"; then
+    echo "Container '$container_name' exists inside 'qm'."
+  else
+    echo "Container '$container_name' does NOT exist inside 'qm'."
+    echo "Output from qm's podman:"
+    echo "$output"
+    exit 1
+  fi
+}
+
+print_debug_info() {
+    echo
+    echo "===================================="
+    echo "Printing $SOCKET"
+    echo "===================================="
+    cat $SOCKET
+
+    echo
+    echo "===================================="
+    echo "Printing $CLIENT"
+    echo "===================================="
+    cat $CLIENT
+
+    echo
+    echo "===================================="
+    echo "Printing $SERVER"
+    echo "===================================="
+    cat $SERVER
+
+    if [[ -n $EXTRA_VOLUME ]]; then
+        echo "===================================="
+        echo "Printing $EXTRA_VOLUME"
+        echo "===================================="
+        cat $EXTRA_VOLUME
+
+        echo "ls -laZ ${VOLUME_PATH%%:*} in the HOST"
+        ls -laZ "${VOLUME_PATH%%:*}"
+    fi
+
+    echo
+    echo "===================================="
+    echo "ls -laZ ${VOLUME_PATH%%:*} in the HOST"
+    echo "===================================="
+    find "${VOLUME_PATH%%:*}" -name '*ipc*' -exec ls -laZ {} +
+
+    echo
+    echo "===================================="
+    echo "ls -laZ ${VOLUME_PATH%%:*} in the QM"
+    echo "===================================="
+    podman exec -it qm bash -c "ls -laZ ${VOLUME_PATH%%:*} | grep ipc"
+}
+
+check_container_exists() {
+    local container_name="systemd-ipc_server"
+    echo "Checking if container '$container_name' exists and is running..."
+
+    if podman ps --format "{{.Names}}" | grep -q "^${container_name}$"; then
+        echo "Container '$container_name' is running."
+    else
+        echo "Container '$container_name' is NOT running."
+        exit 1
+    fi
+}
+
+echo "Creating IPC files for mode: ASIL to QM"
+
+# Define file paths for both modes
+QMQM_SOCKET=""
+QMQM_EXTRA_VOLUME=""
+QMQM_SERVER="/etc/qm/containers/systemd/ipc_server.container"
+QMQM_CLIENT="/etc/qm/containers/systemd/ipc_client.container"
+
+ASIL_SOCKET="/etc/systemd/system/ipc_server.socket"
+ASIL_SERVER="/etc/containers/systemd/ipc_server.container"
+ASIL_CLIENT="/etc/qm/containers/systemd/ipc_client.container"
+ASIL_EXTRA_VOLUME="/etc/containers/systemd/qm.container.d/10-extra-volume.conf"
+
+# asil to qm
+echo "Cleaning up qm-to-qm files..."
+rm -f "$QMQM_SOCKET $QMQM_SERVER $QMQM_CLIENT $QMQM_EXTRA_VOLUME"
+
+SOCKET=$ASIL_SOCKET
+SERVER=$ASIL_SERVER
+CLIENT=$ASIL_CLIENT
+EXTRA_VOLUME="$ASIL_EXTRA_VOLUME"
+
+ENVIRONMENT="Environment=SOCKET_PATH=/run/ipc/ipc.socket"
+LISTEN_PATH="%t/ipc/ipc.socket"
+VOLUME_PATH="/run/ipc/:/run/ipc/"
+
+# Create ipc_server.socket
+echo "Creating $SOCKET"
+cat <<EOF > "$SOCKET"
+[Unit]
+Description=IPC Server Socket for $MODE
+[Socket]
+ListenStream=$LISTEN_PATH
+SELinuxContextFromNet=yes
+
+[Install]
+WantedBy=sockets.target
+EOF
+
+ASIL_VOLUME_DIR="${ASIL_EXTRA_VOLUME%/*}"
+mkdir -p "$ASIL_VOLUME_DIR"
+echo "Creating $EXTRA_VOLUME"
+cat <<EOF > "$EXTRA_VOLUME"
+[Unit]
+Requires=ipc_server
+
+[Container]
+Volume=$VOLUME_PATH
+EOF
+
+echo "Creating $SERVER"
+# Create ipc_server.container
+cat <<EOF > "$SERVER"
+[Unit]
+Description=Demo server service container ($MODE)
+Requires=ipc_server.socket
+After=ipc_server.socket
+[Container]
+Image=localhost/ipc-server:latest
+Network=none
+$ENVIRONMENT
+Volume=$VOLUME_PATH
+SecurityLabelType=ipc_t
+[Service]
+Restart=always
+Type=notify
+[Install]
+WantedBy=multi-user.target
+EOF
+
+echo "Creating $CLIENT"
+# Create ipc_client.container
+cat <<EOF > "$CLIENT"
+[Unit]
+Description=Demo client service container ($MODE)
+[Container]
+Image=localhost/ipc-client:latest
+Network=none
+$ENVIRONMENT
+Volume=$VOLUME_PATH
+SecurityLabelType=qm_container_ipc_t
+[Service]
+Restart=always
+[Install]
+WantedBy=multi-user.target
+EOF
+
+echo "systemctl daemon reload..."
+systemctl daemon-reload
+
+echo "restart ipc_server.socket"
+systemctl restart ipc_server.socket
+
+echo "restart ipc_server"
+systemctl restart ipc_server
+
+echo "restarting qm..."
+systemctl restart qm
+sleep 5
+
+daemon_reload_in_qm
+check_container_exists
+
+echo "qm: systemctl status ipc_client"
+podman exec -it qm bash -c "systemctl status ipc_client"
+
+#check_nested_container_exists "systemd-ipc_client"
+restart_ipc_client_in_qm
+
+echo "qm: systemctl status ipc_client"
+podman exec -it qm bash -c "systemctl status ipc_client"
+
+show_qm_podman_ps
+check_ipc_client_logs
+print_debug_info

--- a/tests/qm-ipc/scripts/common/build.sh
+++ b/tests/qm-ipc/scripts/common/build.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -euo pipefail
+
+# Build the server image; pass the build argument for FEDORA_VERSION
+echo "==========="
+pwd
+echo "==========="
+
+echo "====ls====="
+ls 
+echo "==========="
+
+echo "====ls ../====="
+ls ../
+echo "====ls====="
+
+pushd scripts/common/server
+podman build \
+  --file Containerfile \
+  --build-arg FEDORA_VERSION=41 \
+  --tag ipc-server:latest .
+popd
+
+podman run --rm -d ipc-server:latest
+
+# Build the client image; pass the build argument for FEDORA_VERSION
+echo "==========="
+pwd
+echo "==========="
+pushd scripts/common/client
+podman build \
+  --file Containerfile \
+  --build-arg FEDORA_VERSION=41 \
+  --tag ipc-client:latest .
+popd
+podman run --rm -d ipc-client:latest
+

--- a/tests/qm-ipc/scripts/common/client/Containerfile
+++ b/tests/qm-ipc/scripts/common/client/Containerfile
@@ -1,0 +1,11 @@
+ARG FEDORA_VERSION=41
+
+FROM fedora:${FEDORA_VERSION}
+
+RUN dnf install -y dnf-plugins-core \
+    && dnf -y update \
+    && dnf install -y python3-devel \
+    && dnf clean all
+
+COPY client.py /usr/bin/ipc-client
+CMD [ "ipc-client" ]

--- a/tests/qm-ipc/scripts/common/client/client.py
+++ b/tests/qm-ipc/scripts/common/client/client.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Client script to send messages over a UNIX domain socket."""
+
+import datetime
+import os
+import socket
+import sys
+import time
+
+SOCKET_PATH = os.environ.get("SOCKET_PATH", "/run/ipc/ipc.sock")
+
+
+def systemd_print(*args):
+    """Print to stdout and flush, useful for systemd logging."""
+    print(*args)
+    sys.stdout.flush()
+
+
+class SimpleMessage:
+    """Represents a simple message with the current timestamp."""
+
+    def __init__(self):
+        """Initialize the message with the current datetime."""
+        self.now = datetime.datetime.now()
+
+    def __str__(self) -> str:
+        """Return the formatted time string."""
+        return self.now.strftime("%H:%M:%S") + os.linesep
+
+    def to_bytes(self) -> bytes:
+        """Return the message as bytes."""
+        return self.__str__().encode()
+
+
+def send_loop():
+    """Connect to the UNIX socket and send messages in a loop."""
+    with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
+        systemd_print("Connecting to:", SOCKET_PATH)
+        sock.connect(SOCKET_PATH)
+
+        while True:
+            msg = SimpleMessage().to_bytes()
+            systemd_print("Sending message:", msg)
+            sock.sendall(msg)
+            time.sleep(1)
+
+
+if __name__ == "__main__":
+    while True:
+        try:
+            send_loop()
+        except OSError as e:
+            systemd_print("Connection failed:", e)
+            systemd_print("Retrying...")
+            time.sleep(5)

--- a/tests/qm-ipc/scripts/common/server/Containerfile
+++ b/tests/qm-ipc/scripts/common/server/Containerfile
@@ -1,0 +1,11 @@
+ARG FEDORA_VERSION=41
+
+FROM fedora:${FEDORA_VERSION}
+
+RUN dnf install -y dnf-plugins-core \
+    && dnf -y update \
+    && dnf install -y python3-devel \
+    && dnf clean all
+
+COPY server.py /usr/bin/ipc-server
+CMD [ "ipc-server" ]

--- a/tests/qm-ipc/scripts/common/server/server.py
+++ b/tests/qm-ipc/scripts/common/server/server.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""
+UNIX domain socket server that receives timestamp messages.
+
+This script listens on a socket path and accepts incoming client connections.
+Each client sends time-stamped messages which the server prints upon receipt.
+"""
+
+import os
+import socket
+import sys
+
+SOCKET_PATH = os.environ.get("SOCKET_PATH", "/run/ipc/ipc.sock")
+
+
+def systemd_print(*args):
+    """Print messages to stdout and flush for journald compatibility."""
+    print(*args)
+    sys.stdout.flush()
+
+
+class SimpleServer:
+    """UNIX domain socket server."""
+
+    def __init__(self, path: str):
+        """
+        Initialize the server.
+
+        Args:
+            path (str): Path to the UNIX domain socket.
+        """
+        self.path = path
+
+    def __enter__(self):
+        """Enter context manager and start the socket server."""
+        self.sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        if os.path.exists(self.path):
+            os.remove(self.path)
+        self.sock.bind(self.path)
+        self.sock.listen()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Exit context manager and clean up the socket."""
+        self.sock.close()
+        if os.path.exists(self.path):
+            os.remove(self.path)
+
+    def run(self):
+        """Run the server loop to accept and print messages from clients."""
+        systemd_print("Listening on:", self.path)
+        while True:
+            conn, _ = self.sock.accept()
+            with conn:
+                while True:
+                    data = conn.recv(1024)
+                    if not data:
+                        break
+                    systemd_print("Received:", data.decode().strip())
+
+
+def main():
+    """Start the SimpleServer using the configured socket path."""
+    with SimpleServer(SOCKET_PATH) as server:
+        server.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/qm-ipc/scripts/qm-to-qm/qm-to-qm.sh
+++ b/tests/qm-ipc/scripts/qm-to-qm/qm-to-qm.sh
@@ -1,0 +1,156 @@
+#!/bin/bash
+
+daemon_reload_in_qm() {
+    echo "qm: systemctl daemon-reload inside qm..."
+    podman exec -it qm bash -c "systemctl daemon-reload"
+}
+
+restart_ipc_client_in_qm() {
+    echo "qm: restart ipc_client inside qm..."
+    podman exec -it qm bash -c "podman restart systemd-ipc_client"
+    sleep 15
+}
+
+show_qm_podman_ps() {
+    echo "qm: podman ps inside qm..."
+    podman exec -it qm bash -c "podman ps"
+}
+
+check_nested_ipc_containers_exist() {
+  local nested_containers=("systemd-ipc_client" "systemd-ipc_server")
+  local missing=0
+
+  echo "Checking nested containers inside 'qm'..."
+
+  # Capture the list of nested container names inside 'qm'
+  local container_list
+  container_list=$(podman exec -it qm podman ps --all --format '{{.Names}}' | tr -d '\r')
+
+  for name in "${nested_containers[@]}"; do
+    if ! grep -q "^${name}$" <<< "$container_list"; then
+      echo "Error: Nested container '$name' does not exist inside 'qm'."
+      missing=1
+    fi
+  done
+
+  if [[ $missing -eq 1 ]]; then
+    exit 1
+  else
+    echo "Both nested containers exist inside 'qm'."
+  fi
+}
+
+
+check_ipc_client_logs() {
+    echo "qm: podman logs systemd-ipc_client"
+    if podman exec -it qm bash -c "podman logs systemd-ipc_client" | grep -Eiq "permission denied|no such file or directory"; then
+        echo "systemd-ipc_client has failed"
+        exit 1
+    fi
+}
+
+print_debug_info() {
+    echo
+    echo "===================================="
+    echo "Printing $CLIENT"
+    echo "===================================="
+    cat $CLIENT
+
+    echo
+    echo "===================================="
+    echo "Printing $SERVER"
+    echo "===================================="
+    cat $SERVER
+
+    if [[ -n $EXTRA_VOLUME ]]; then
+        echo "===================================="
+        echo "Printing $EXTRA_VOLUME"
+        echo "===================================="
+        cat "$EXTRA_VOLUME"
+
+        echo "ls -laZ ${VOLUME_PATH%%:*} in the HOST"
+        ls -laZ "${VOLUME_PATH%%:*}"
+    fi
+
+    echo
+    echo "===================================="
+    echo "ls -laZ ${VOLUME_PATH%%:*} in the HOST"
+    echo "===================================="
+    find "${VOLUME_PATH%%:*}" -name '*ipc*' -exec ls -laZ {} +
+
+    echo
+    echo "===================================="
+    echo "ls -laZ ${VOLUME_PATH%%:*} in the QM"
+    echo "===================================="
+    podman exec -it qm bash -c "ls -laZ ${VOLUME_PATH%%:*} | grep ipc"
+}
+
+MODE="$1"
+
+echo "Creating IPC files for mode: $MODE"
+
+# Define file paths for both modes
+QMQM_SERVER="/etc/qm/containers/systemd/ipc_server.container"
+QMQM_CLIENT="/etc/qm/containers/systemd/ipc_client.container"
+
+echo "Cleaning up asil-to-qm files..."
+rm -f "$ASIL_SOCKET" "$ASIL_SERVER" "$ASIL_CLIENT" "$ASIL_EXTRA_VOLUME"
+
+VOLUME_PATH=/run/:/run/
+ENVIRONMENT="Environment=SOCKET_PATH=/run/ipc.sock"
+
+SERVER=$QMQM_SERVER
+CLIENT=$QMQM_CLIENT
+
+# Create ipc_server.socket
+echo "Creating $SERVER"
+# Create ipc_server.container
+cat <<EOF > "$SERVER"
+[Unit]
+Description=Demo server service container ($MODE)
+[Container]
+Image=localhost/ipc-server:latest
+Network=none
+$ENVIRONMENT
+Volume=$VOLUME_PATH
+SecurityLabelLevel=s0:c1,c2
+#SecurityLabelType=ipc_t
+[Service]
+Restart=always
+Type=notify
+[Install]
+WantedBy=multi-user.target
+EOF
+
+echo "Creating $CLIENT"
+# Create ipc_client.container
+cat <<EOF > "$CLIENT"
+[Unit]
+Description=Demo client service container ($MODE)
+Requires=ipc_server.service
+After=ipc_server.service
+
+[Container]
+Image=localhost/ipc-client:latest
+Network=none
+$ENVIRONMENT
+Volume=$VOLUME_PATH
+SecurityLabelLevel=s0:c1,c2
+[Service]
+Restart=always
+[Install]
+WantedBy=multi-user.target
+EOF
+
+echo "Reloading systemd and restarting containers (qm-to-qm)..."
+systemctl daemon-reload
+systemctl restart qm
+sleep 15
+
+daemon_reload_in_qm
+
+print_debug_info
+restart_ipc_client_in_qm
+check_nested_ipc_containers_exist
+check_ipc_client_logs
+show_qm_podman_ps

--- a/tests/qm-ipc/test_ipc.sh
+++ b/tests/qm-ipc/test_ipc.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# shellcheck disable=SC1091
+. ../e2e/lib/utils
+
+./scripts/common/build.sh
+
+info_message "Running QM IPC tests..."
+
+if ! ./scripts/asil-to-qm/asil-to-qm.sh ; then
+  echo "FAIL: ASIL to QM IPC tests failed."
+  exit 1
+fi
+
+if ! ./scripts/qm-to-qm/qm-to-qm.sh; then
+  echo "FAIL: QM to QM IPC tests failed."
+  exit 1
+fi


### PR DESCRIPTION
Add tests for ASIL to QM and QM to QM communications.

## Summary by Sourcery

Add end-to-end QM IPC tests covering ASIL-to-QM and QM-to-QM communication scenarios with systemd and Podman containers

Tests:
- Add ASIL-to-QM and QM-to-QM IPC verification scripts to test container communication via systemd and Podman
- Add a test runner script and FMF metadata to orchestrate execution of QM IPC tests