### PR TITLE
build_kvm_container: replace openssl to fedora

### DIFF
--- a/subsystems/kvm/usr/share/qm/kvm/build_kvm_container.sh
+++ b/subsystems/kvm/usr/share/qm/kvm/build_kvm_container.sh
@@ -7,7 +7,7 @@ ARCHS=("amd64" "aarch64")
 IMAGE_NAME="kvm"
 TAG="latest"
 MANIFEST_NAME="${IMAGE_NAME}-manifest:${TAG}"
-FEDORA_USER_PASSWORD=${FEDORA_USER_PASSWORD:-$(openssl rand -base64 12)}
+FEDORA_USER_PASSWORD=${FEDORA_USER_PASSWORD:-fedora}
 
 #IMG_REG=quay.io
 #IMG_ORG=qm-images


### PR DESCRIPTION
Set default password to fedora instead of dynamic pass to generate the image.

## Summary by Sourcery

Enhancements:
- Set FEDORA_USER_PASSWORD default to "fedora" instead of generating a random password