### PR TITLE
Makefile: reduce the make dist files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,15 @@ dist: ##             - Creates the QM distribution package
 		--exclude='.git' \
 		--dereference \
 		--exclude='.gitignore' \
+		--exclude='.fmf' \
+		--exclude='.packit.*' \
+		--exclude='.pre-commit*' \
+		--exclude='.readthedocs.yaml' \
 		--exclude='demos' \
+		--exclude='docs' \
+		--exclude='plans' \
+		--exclude='subsystems' \
+		--exclude='tests' \
 		--exclude='.github' \
 		--transform s/qm/qm-${VERSION}/ \
 		-f /tmp/v${VERSION}.tar.gz ../qm


### PR DESCRIPTION
## Summary by Sourcery

Streamline the distribution package by updating the Makefile to exclude unnecessary files and directories from the tarball

Enhancements:
- Add exclusion patterns for repository metadata and config files (.github, .fmf, .packit.*, .pre-commit*, .readthedocs.yaml)
- Exclude development directories such as docs, demos, plans, subsystems, and tests from the dist target