### PR TITLE
Adding verification check for flood testing

### DIFF
--- a/tests/ffi/common/prepare.sh
+++ b/tests/ffi/common/prepare.sh
@@ -51,6 +51,13 @@ disk_cleanup() {
 reload_config() {
    exec_cmd "systemctl daemon-reload"
    exec_cmd "systemctl restart qm"
+   # Add verification loop for qm status
+   if timeout 30 bash -c "until systemctl is-active qm; do sleep 1; done"; then
+       info_message "PASS: Service QM is Active."
+   else
+       info_message "FAIL: Service QM is not Active"
+       exit 1
+   fi
 }
 
 running_container_in_qm() {


### PR DESCRIPTION
Fix #909 

Add check for qm readiness,

after systemctl qm restart

## Summary by Sourcery

Verify the QM service is active after restart in the test setup

Enhancements:
- Add a timeout-based loop in reload_config to ensure the QM systemd service is active

Tests:
- Fail test setup if the QM service does not become active within 30 seconds