### PR TITLE
qmctl: Allow commands to succeed with empty output

### DIFF
--- a/tests/qmctl-test/scripts/qmctl_exec.sh
+++ b/tests/qmctl-test/scripts/qmctl_exec.sh
@@ -6,19 +6,24 @@
 QMCTL_SCRIPT="../../tools/qmctl/qmctl"
 CONTAINER_NAME="alpine-podman"
 
+# Cleanup function that will be called on script exit
+cleanup() {
+    if python3 $QMCTL_SCRIPT exec test -f /tmp/test_file > /dev/null 2>&1; then
+        info_message "Removing test file..."
+        python3 $QMCTL_SCRIPT exec rm -f /tmp/test_file > /dev/null 2>&1 || true
+    fi
+}
+
+# Set up trap to call cleanup function on script exit
+trap cleanup EXIT
+
 # Cleanup any existing container from previous runs
 info_message "Cleaning up any existing test container..."
 python3 $QMCTL_SCRIPT exec podman rm -f "$CONTAINER_NAME" > /dev/null 2>&1 || true
 
-# Verify container doesn't exist
-if python3 $QMCTL_SCRIPT exec podman ps -a | grep -q "$CONTAINER_NAME"; then
-    fail_message "Container $CONTAINER_NAME still exists after cleanup"
-    exit 1
-fi
-
 # Create new container
 info_message "Creating test container..."
-python3 $QMCTL_SCRIPT exec podman run -d --name "$CONTAINER_NAME" alpine tail -f /dev/null
+python3 $QMCTL_SCRIPT exec podman run -d --name "$CONTAINER_NAME" --replace alpine tail -f /dev/null
 
 # Verify container was created
 if ! python3 $QMCTL_SCRIPT exec podman ps -a | grep -q "$CONTAINER_NAME"; then
@@ -26,7 +31,19 @@ if ! python3 $QMCTL_SCRIPT exec podman ps -a | grep -q "$CONTAINER_NAME"; then
     exit 1
 fi
 
-# NOTE: We don't clean up the container here as subsequent tests (execin) may need it
+# Test that touch command returns exit code 0 with empty output
+info_message "Testing touch command with empty output..."
+touch_output=$(python3 $QMCTL_SCRIPT exec touch /tmp/test_file 2>&1)
+touch_exit=$?
+
+if [ $touch_exit -ne 0 ]; then
+    fail_message "Touch command failed with exit code $touch_exit"
+    exit 1
+fi
+
+if [ -n "$touch_output" ]; then
+    fail_message "Touch command should have empty output but got: '$touch_output'"
+    exit 1
+fi
 
 pass_message "qmctl exec command executed successfully"
-exit 0

--- a/tests/qmctl-test/scripts/qmctl_execin.sh
+++ b/tests/qmctl-test/scripts/qmctl_execin.sh
@@ -39,4 +39,3 @@ fi
 python3 $QMCTL_SCRIPT execin "$CONTAINER_NAME" rm -f "$TMP_FILE" > /dev/null 2>&1 || true
 
 pass_message "qmctl execin command executed successfully"
-exit 0

--- a/tools/qmctl/qmctl
+++ b/tools/qmctl/qmctl
@@ -208,9 +208,6 @@ class QmController:
                 f"stderr: {result.stderr.strip()}"
             )
 
-        if not result.stdout.strip():
-            raise QmError(f"{context} No output returned.")
-
     def _extract_devices_from_config(self) -> list[str]:
         """Extract device paths from config file."""
         devices = []
@@ -542,9 +539,10 @@ class QmController:
                 f"Failed to execute command in container '{self.container}'"
             )
 
-            self._print_output(
-                {"output": result.stdout.strip()}
-            )
+            if output := result.stdout.strip():
+                self._print_output(
+                    {"output": output}
+                )
 
         except Exception as e:
             self._print_error_and_exit(QmError(str(e)))


### PR DESCRIPTION
qmctl: Allow commands to succeed with empty output

This change fixes qmctl to properly handle commands that execute
successfully but produce no output (like touch, rm, etc.).

Changes:
- Removed strict check that failed commands with empty output
- Modified exec function to only print output when there is actual content
- Updated tests to validate both exit code and output behavior

closes https://github.com/containers/qm/issues/914"