### PR TITLE
update the container image tag to qm-0.7.4.z

### DIFF
--- a/create-seccomp-rules
+++ b/create-seccomp-rules
@@ -37,69 +37,11 @@ function add_syscall_deny_list() {
     local syscall_name="$1"
     local seccomp_file_path="$2"
 
-    local temp_file
     temp_file=$(mktemp)
-
-    if [[ "$syscall_name" == "sched_setscheduler" ]]; then
-        jq --tab \
-           '.syscalls += [
-               {
-                   "names": ["sched_setscheduler"],
-                   "action": "SCMP_ACT_ALLOW",
-                   "args": [
-                       {
-                           "index": 1,
-                           "value": 0,
-                           "valueTwo": 0,
-                           "op": "SCMP_CMP_EQ"
-                       }
-                   ],
-                   "comment": "",
-                   "includes": {},
-                   "excludes": {}
-               },
-               {
-                   "names": ["sched_setscheduler"],
-                   "action": "SCMP_ACT_ALLOW",
-                   "args": [
-                       {
-                           "index": 1,
-                           "value": 3,
-                           "valueTwo": 0,
-                           "op": "SCMP_CMP_EQ"
-                       }
-                   ],
-                   "comment": "",
-                   "includes": {},
-                   "excludes": {}
-               },
-               {
-                   "names": ["sched_setscheduler"],
-                   "action": "SCMP_ACT_ALLOW",
-                   "args": [
-                       {
-                           "index": 1,
-                           "value": 5,
-                           "valueTwo": 0,
-                           "op": "SCMP_CMP_EQ"
-                       }
-                   ],
-                   "comment": "",
-                   "includes": {},
-                   "excludes": {}
-               }
-           ]' "$seccomp_file_path" > "$temp_file" && mv "$temp_file" "$seccomp_file_path"
-    else
-        jq --tab \
-           --arg syscall "$syscall_name" \
-           '.syscalls += [{
-               "names": [$syscall],
-               "action": "SCMP_ACT_ERRNO",
-               "args": [],
-               "errnoRet": 1,
-               "errno": "EPERM"
-           }]' "$seccomp_file_path" > "$temp_file" && mv "$temp_file" "$seccomp_file_path"
-    fi
+    jq --tab \
+       --arg syscall "$syscall_name" \
+       '.syscalls += [{"names": [$syscall], "action": "SCMP_ACT_ERRNO", "args": [], "errnoRet": 1, "errno": "EPERM"}]' \
+       "${seccomp_file_path}" > "$temp_file" && mv "$temp_file" "${seccomp_file_path}"
 
     rm "$temp_file" &> /dev/null
 }

--- a/tests/e2e/tools/FFI/deny_set_scheduler/execute_set_scheduler.c
+++ b/tests/e2e/tools/FFI/deny_set_scheduler/execute_set_scheduler.c
@@ -1,4 +1,3 @@
-#define _GNU_SOURCE
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -6,55 +5,24 @@
 #include <errno.h>
 #include <string.h>
 
-int main(int argc, char *argv[]) {
+int main() {
     int pid = getpid();
-    int policy;  // Desired scheduling policy
-    char *policy_name;
+    int policy = SCHED_FIFO;  // Desired scheduling policy
     struct sched_param param;
 
-    if (argc == 2)
-    {
-        policy_name = argv[1];
-
-        if (strcmp(policy_name, "SCHED_OTHER")==0) {
-            policy = SCHED_OTHER;
-        } else if (strcmp(policy_name, "SCHED_BATCH")==0) {
-            policy = SCHED_BATCH;
-        } else if (strcmp(policy_name, "SCHED_IDLE")==0) {
-            policy = SCHED_IDLE;
-        } else if (strcmp(policy_name, "SCHED_FIFO")==0) {
-            policy = SCHED_FIFO;
-        } else if (strcmp(policy_name, "SCHED_RR")==0) {
-            policy = SCHED_RR;
-        } else {
-            printf("Unknown policy.\n");
-            return EXIT_FAILURE;
-        }
-    }
-    else if (argc > 2)
-    {
-        printf("Too many policies supplied.\n");
-        return EXIT_FAILURE;
-    }
-    else
-    {
-        printf("One policy expected.\n");
-        return EXIT_FAILURE;
-    }
-
-    // Assign the maximum priority for the policy
+    // Assign the maximum priority for the SCHED_FIFO policy
     param.sched_priority = sched_get_priority_max(policy);
     if (param.sched_priority == -1) {
-        fprintf(stderr, "Failed to get max priority for %s: %s\n", policy_name, strerror(errno));
+        fprintf(stderr, "Failed to get max priority for SCHED_FIFO: %s\n", strerror(errno));
         return EXIT_FAILURE;
     }
 
     // Attempt to set the scheduling policy and priority
     if (sched_setscheduler(pid, policy, &param) == -1) {
-        printf("sched_setscheduler(%s) failed: errno=%d (%s)", policy_name, errno, strerror(errno));
+        fprintf(stderr, "Failed to set scheduler: %s\n", strerror(errno));
         return EXIT_FAILURE;
-    } else {
-        printf("sched_setscheduler(%s) succeeded.", policy_name);
-        return EXIT_SUCCESS;
     }
+
+    printf("Scheduler set to SCHED_FIFO with priority %d\n", param.sched_priority);
+    return EXIT_SUCCESS;
 }

--- a/tests/ffi/common/ffi-qm.container
+++ b/tests/ffi/common/ffi-qm.container
@@ -4,7 +4,7 @@ After=local-fs.target
 
 [Container]
 ContainerName=ffi-qm
-Image=quay.io/centos-sig-automotive/ffi-tools:latest
+Image=quay.io/centos-sig-automotive/ffi-tools:qm-0.7.4.z
 Exec=sleep infinity
 StopTimeout=1
 

--- a/tests/ffi/deny_set_scheduler/test.sh
+++ b/tests/ffi/deny_set_scheduler/test.sh
@@ -3,44 +3,19 @@
 # shellcheck source=tests/ffi/common/prepare.sh
 . ../common/prepare.sh
 
-policy_arr=(SCHED_OTHER SCHED_BATCH SCHED_IDLE SCHED_FIFO SCHED_RR)
-num_of_failed_policy=0
+expected_result="Failed to set scheduler: Function not implemented"
 
 trap disk_cleanup EXIT
 prepare_test
 reload_config
 
 running_container_in_qm
-# Copy the test from ffi-qm container to qm container
-podman exec -it qm /usr/bin/podman cp ffi-qm:/root/tests/FFI/bin/QM/test_sched_setscheduler /var/
 
-for policy in "${policy_arr[@]}"; do
-    # Run the test inside qm container
-    return_from_setscheduler=$(podman exec -it qm ./var/test_sched_setscheduler "$policy")
+return_from_setscheduler=$(podman exec -it qm /usr/bin/podman exec -it ffi-qm ./QM/test_sched_setscheduler)
 
-    # Assign the expected result according to the policy
-    if [[ "$policy" == "SCHED_OTHER" || "$policy" == "SCHED_BATCH" || "$policy" == "SCHED_IDLE" ]]; then
-        expected_result="sched_setscheduler($policy) succeeded."
-    elif [[ "$policy" == "SCHED_FIFO" || "$policy" == "SCHED_RR" ]]; then
-        expected_result="sched_setscheduler($policy) failed: errno=38 (Function not implemented)"
-    fi
-
-    # Check that the result is the same as expected
-    if [[ "${return_from_setscheduler}" == "${expected_result}" ]]; then
-        info_message "$expected_result"
-        info_message "PASS: The result of sched_setscheduler($policy) is as expected in QM."
-    else
-        info_message "$return_from_setscheduler"
-        info_message "FAIL: The result of sched_setscheduler($policy) is not what is expected in QM."
-        ((num_of_failed_policy++))
-    fi
-done
-
-# If there is a failed policy, then this test returns failure
-if [[ $num_of_failed_policy -gt 0 ]]; then
-    info_message "FAIL: sched_setscheduler() test failed."
-    exit 1
+if [[ "${return_from_setscheduler}" =~ ${expected_result} ]]; then
+    info_message "PASS: set_scheduler() syscall denied in QM."
 else
-    info_message "PASS: sched_setscheduler() test passed."
-    exit 0
+    info_message "FAIL: set_scheduler() syscall can be executed in QM."
+    exit 1
 fi

--- a/tests/ffi/deny_set_scheduler/test.sh
+++ b/tests/ffi/deny_set_scheduler/test.sh
@@ -3,7 +3,7 @@
 # shellcheck source=tests/ffi/common/prepare.sh
 . ../common/prepare.sh
 
-expected_result="Failed to set scheduler: Function not implemented"
+expected_result="Failed to set scheduler: Operation not permitted"
 
 trap disk_cleanup EXIT
 prepare_test


### PR DESCRIPTION
This modification makes the test cases of this branch (qm-0.7.4.z) use the ffi-tools container image with tag qm-0.7.4.z

## Summary by Sourcery

Streamline the FFI scheduling tests for QM 0.7.4.z by hard-coding SCHED_FIFO, simplifying test logic and assertions, and updating container references to the qm-0.7.4.z image tag.

Enhancements:
- Hard-code SCHED_FIFO in execute_set_scheduler.c and remove dynamic policy parsing with corresponding error messages
- Simplify test.sh to invoke the scheduler test once, validate only denial of the set_scheduler syscall, and remove policy loops and copy steps
- Update common test configurations to reference the ffi-tools container image tagged qm-0.7.4.z