### PR TITLE
tests: Add BlueChI socket volume mount to QM container configuration

### DIFF
--- a/tests/e2e/set-ffi-env-e2e
+++ b/tests/e2e/set-ffi-env-e2e
@@ -164,15 +164,26 @@ setup_qm_services() {
       curl "${QM_GH_URL}"  > /usr/share/qm/setup
       chmod +x /usr/share/qm/setup
   fi
+
   # Curl files into here,
   # Fix: default setup:main should be removed on next qm release
   /usr/share/qm/setup --hostname localrootfs
   # Update QM relimits
   set_qm_rlimits
+
+  # Create BlueChi socket volume mount drop-in file
+  info_message "Creating BlueChi socket volume mount drop-in file..."
+  mkdir -p /etc/containers/systemd/qm.container.d/
+  cat > /etc/containers/systemd/qm.container.d/bluechi-socket.conf << 'EOF'
+[Container]
+Volume=/run/bluechi/bluechi.sock:/run/bluechi.sock
+EOF
+  info_message "BlueChi socket volume mount drop-in file created successfully"
+
   cat > /etc/bluechi/controller.conf << 'EOF'
 [bluechi-controller]
 AllowedNodeNames=qm.localrootfs,localrootfs
-ControllerPort=842
+UseTCP=false
 LogLevel=INFO
 LogTarget=journald
 LogIsQuiet=false
@@ -180,13 +191,13 @@ EOF
 cat > /etc/bluechi/agent.conf.d/00-default.conf << 'EOF'
 [bluechi-agent]
 NodeName=localrootfs
+ControllerAddress=unix:path=/run/bluechi/bluechi.sock
 EOF
 
-controller_host_ip=$(hostname -I | awk '{print $1}')
 qm_bluechi_agent_config_file="/etc/qm/bluechi/agent.conf.d/agent.conf"
 if [[ -f "${qm_bluechi_agent_config_file}" ]]; then
-    if ! grep "ControllerHost=${controller_host_ip}" "${qm_bluechi_agent_config_file}" >/dev/null; then
-        sed -i '$a \ControllerHost='"${controller_host_ip}"'' ${qm_bluechi_agent_config_file}
+    if ! grep "ControllerAddress=unix:path=/run/bluechi/bluechi.sock" "${qm_bluechi_agent_config_file}" >/dev/null; then
+        sed -i '$a \ControllerAddress=unix:path=/run/bluechi.sock' ${qm_bluechi_agent_config_file}
     fi
 else
     echo "Configuration file not found: ${qm_bluechi_agent_config_file}"


### PR DESCRIPTION
- Add Volume=/run/bluechi/bluechi.socket:/run/bluechi.socket to qm.container
- This enables communication between host BlueChI controller and QM container
- Modification happens in set-ffi-env-e2e before setup script execution
- Includes safety checks to avoid duplicate volume mounts

## Summary by Sourcery

Tests:
- Mount host /run/bluechi/bluechi.socket into QM container in set-ffi-env-e2e script with idempotent checks

Closes: https://github.com/containers/qm/issues/705

## Summary by Sourcery

Mount the BlueChi socket into QM containers and switch tests to use the Unix socket endpoint, while simplifying network setup and adding verbose failure logs for easier troubleshooting.

New Features:
- Mount the host BlueChI socket into the QM container via a systemd drop-in with idempotent checks
- Update the agent-flood test to connect over the Unix socket instead of TCP

Enhancements:
- Remove host IP detection logic for QM network mode
- Add detailed debug logging in the test script on container failures
- Inject the socket mount in the e2e setup script before container startup