### PR TITLE
Fix broken aib test

### DIFF
--- a/tests/aib/check_qm_with_aib.sh
+++ b/tests/aib/check_qm_with_aib.sh
@@ -9,10 +9,10 @@ exec_cmd "curl -o qm.aib.yml https://gitlab.com/CentOS/automotive/src/automotive
 USE_QM_COPR="${PACKIT_COPR_PROJECT:-@centos-automotive-sig/qm-next}"
 COPR_URL="https://download.copr.fedorainfracloud.org/results/${USE_QM_COPR}/epel-9-$(uname -m)/"
 #shellcheck disable=SC2089
-EXTRA_REPOS='extra_repos=[{"id":"qm_build","baseurl":"'"$COPR_URL"'"}]'
+EXTRA_REPOS="extra_repos=[{id: qm_build, baseurl: $COPR_URL}]"
 
 
 # Run AIB in container
 exec_cmd "curl -o auto-image-builder.sh https://gitlab.com/CentOS/automotive/src/automotive-image-builder/-/raw/main/auto-image-builder.sh?ref_type=heads"
 #shellcheck disable=SC2027,SC2090,SC2086
-exec_cmd "/bin/bash auto-image-builder.sh build --export qcow2 --define '"$EXTRA_REPOS"' qm.aib.yml qm.qcow2"
+exec_cmd "/bin/bash auto-image-builder.sh build --export qcow2 --define \\\"$EXTRA_REPOS\\\" qm.aib.yml qm.qcow2"


### PR DESCRIPTION
## Summary by Sourcery

fix #917

Fix the broken AIB test by correcting shell quoting for extra_repos and the build command invocation.

Bug Fixes:
- Correct shell quoting of EXTRA_REPOS definition in check_qm_with_aib.sh
- Properly quote the --define argument in the auto-image-builder.sh invocation

## Summary by Sourcery

Fix broken AIB test by correcting shell quoting for extra_repos and the build command invocation

Bug Fixes:
- Correct shell quoting of EXTRA_REPOS definition in check_qm_with_aib.sh
- Properly escape and quote the --define argument in the auto-image-builder.sh build command