### PR TITLE
Added empty qm.containers.d to QM RPM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,3 +110,4 @@ install: man all ##             - Install QM files (including selinux)
 	install -D -m 755 tools/qm-is-ostree ${DESTDIR}${DATADIR}/qm/qm-is-ostree
 	install -D -m 755 tools/qmctl/qmctl ${DESTDIR}${PREFIX}/bin/qmctl
 	install -D -m 644 tools/qmctl/qmctl.1 ${DESTDIR}${DATADIR}/man/man1/qmctl.1
+	install -d -m 755 ${DESTDIR}${SYSCONFDIR}/containers/systemd/qm.container.d/

--- a/rpm/qm.spec
+++ b/rpm/qm.spec
@@ -157,6 +157,7 @@ fi
 %license LICENSE
 %doc CODE-OF-CONDUCT.md NOTICE README.md SECURITY.md
 %dir %{_datadir}/selinux
+%dir %{_sysconfdir}/containers/systemd/qm.container.d
 %{_datadir}/selinux/*
 %dir %{_datadir}/qm
 %{_datadir}/qm/containers.conf


### PR DESCRIPTION
Added empty qm.containers.d to QM RPM. 
Currently, this drop-in directory needs to be created on the target system each time individually.

## Summary by Sourcery

Automate the creation of the qm.container.d drop-in directory during installation by extending the Makefile and RPM spec to include the new directory, removing the need for manual setup on target systems.

New Features:
- Include an empty qm.container.d drop-in directory in the QM RPM

Enhancements:
- Update the Makefile install target and RPM spec to create the containers/systemd/qm.container.d directory automatically