### PR TITLE
README.developer: update auto-image-builder steps

### DIFF
--- a/docs/devel/README.developer.md
+++ b/docs/devel/README.developer.md
@@ -89,13 +89,11 @@ other example images such as `simple-qm-container` and the `simple-qm`
 image can be found in the images directory of the sample-images repository.
 
 ```bash
-dnf install podman -y && dnf clean all
-git clone https://gitlab.com/CentOS/automotive/sample-images.git
-git submodule update --init
-cd sample-images/
-rm -rf _build #Optional, only relevant after initial build
-rm -rf *.qcow2 #Optional, only relevant after initial build
-./automotive-image-builder/automotive-image-builder build --distro cs9 --mode package --define 'ssh_permit_root_login=true' --define 'ssh_permit_password_auth=true' --define 'extra_repos=[{"id":"local","baseurl":"file:///root/rpmbuild/RPMS/noarch"}]' --define 'extra_rpms=["qm-1.0", "vim-enhanced", "openssh-server", "openssh-clients", "python3", "polkit", "rsync", "strace", "dnf", "gdb"]' --target qemu --export qcow2 images/qm-minimal.mpp.yml cs9-qemu-qm-container.x86_64.qcow2
+curl -Lo qm.aib.yml "https://gitlab.com/CentOS/automotive/src/automotive-image-builder/-/raw/main/examples/qm.aib.yml?ref_type=heads"
+
+curl -Lo auto-image-builder.sh "https://gitlab.com/CentOS/automotive/src/automotive-image-builder/-/raw/main/auto-image-builder.sh?ref_type=heads"
+
+sudo ./auto-image-builder.sh build --distro cs9 --mode package --define \"ssh_permit_root_login=true\" --define \"ssh_permit_password_auth=true\" --define \"extra_repos=[{id: local,baseurl: file:///root/rpmbuild/RPMS/noarch}]\" --define \"extra_rpms=[qm-1.0, vim-enhanced, openssh-server, openssh-clients, python3, polkit, rsync, strace, dnf, gdb]\" --target qemu --export qcow2 qm.aib.yml cs9-qemu-qm-container.x86_64.qcow2
 ```
 
 If you would like more information on building automotive images with automotive-image-builder, please see the


### PR DESCRIPTION
Resolves: https://github.com/containers/qm/issues/704

## Summary by Sourcery

Update developer README to simplify auto-image-builder usage by fetching configuration and helper script via curl and adjusting the build command.

Documentation:
- Fetch the example QM configuration and auto-image-builder script via curl instead of cloning the repository.
- Simplify the build step to use the downloaded config file rather than local submodules and example paths.