### PR TITLE
spec: change {?copr_username}

### DIFF
--- a/rpm/qm.spec
+++ b/rpm/qm.spec
@@ -22,8 +22,7 @@
 %endif
 
 # copr_username is only set on copr environments, not on others like koji
-# Check if copr is owned by rhcontainerbot
-%if "%{?copr_username}" != "rhcontainerbot"
+%if "%{?copr_username}" != "centos-automotive-sig" && "%{?copr_projectname}" != "qm-next"
 %bcond_with copr
 %else
 %bcond_without copr


### PR DESCRIPTION
Resolves: https://github.com/containers/qm/issues/938

## Summary by Sourcery

Enhancements:
- Tighten copr build conditional to only trigger for the centos-automotive-sig user on the qm-next project