### PR TITLE
selinux: policy to permit /dev/shm mount

### DIFF
--- a/qm.te
+++ b/qm.te
@@ -30,8 +30,11 @@ unconfined_domain(ipc_t)
 
 qm_domain_template(qm)
 
+allow qm_t tmpfs_t:dir mounton;
+
 allow qm_container_ipc_t ipc_var_run_t:dir { add_name remove_name write };
 allow qm_container_ipc_t ipc_var_run_t:sock_file { create setattr unlink };
+allow qm_container_ipc_t tmpfs_t:file { open map };
 
 
 #########################################


### PR DESCRIPTION
## Summary by Sourcery

New Features:
- Permit /dev/shm mount in the SELinux policy