### PR TITLE
Update qmctl packaging and tests to use installed CLI

### DIFF
--- a/rpm/qm.spec
+++ b/rpm/qm.spec
@@ -62,6 +62,7 @@ BuildRequires: pkgconfig(systemd)
 BuildRequires: selinux-policy >= %_selinux_policy_version
 BuildRequires: selinux-policy-devel >= %_selinux_policy_version
 BuildRequires: bluechi-selinux
+BuildRequires: python3-devel
 
 Requires: parted
 Requires: containers-common
@@ -116,6 +117,11 @@ sed -i 's|^/run/|/var/run/|' qm.fc
 %install
 # Create the directory for drop-in configurations
 install -d %{buildroot}%{_sysconfdir}/containers/containers.conf.d
+
+# Install Python module for qmctl
+install -d %{buildroot}%{python3_sitelib}/qmctl
+install -m 0644 tools/qmctl/__init__.py %{buildroot}%{python3_sitelib}/qmctl/
+install -m 0644 tools/qmctl/qmctl.py %{buildroot}%{python3_sitelib}/qmctl/
 
 # install policy modules
 %_format MODULES $x.pp.bz2
@@ -181,6 +187,7 @@ fi
 %license LICENSE
 %{_bindir}/qmctl
 %{_mandir}/man1/qmctl.*
+%{python3_sitelib}/qmctl/
 
 %changelog
 %if %{defined autochangelog}

--- a/tests/qmctl-test/scripts/qmctl_error_handling.sh
+++ b/tests/qmctl-test/scripts/qmctl_error_handling.sh
@@ -6,88 +6,86 @@ set -e
 # shellcheck disable=SC1091
 . ../e2e/lib/utils
 
-QMCTL_SCRIPT="../../tools/qmctl/qmctl"
-
 info_message "Starting comprehensive qmctl error handling tests..."
 
 # Test 1: No subcommand (should show usage and fail)
 run_test "No subcommand" 22 "error_pattern" "requires a subcommand" \
-    python3 "$QMCTL_SCRIPT"
+    qmctl
 
 # Test 2: Invalid subcommand
 run_test "Invalid subcommand" 2 "error_pattern" "invalid choice" \
-    python3 "$QMCTL_SCRIPT" invalid_command
+    qmctl invalid_command
 
 # Test 3: Exec without command
 run_test "Exec without command" 22 "error_pattern" "No command provided" \
-    python3 "$QMCTL_SCRIPT" exec
+    qmctl exec
 
 # Test 4: Execin without container name
 run_test "Execin without container" 1 "error_pattern" "No command provided" \
-    python3 "$QMCTL_SCRIPT" execin
+    qmctl execin
 
 # Test 5: Execin with container but no command
 run_test "Execin with container but no command" 1 "error_pattern" "No command provided" \
-    python3 "$QMCTL_SCRIPT" execin some_container
+    qmctl execin some_container
 
 # Test 6: Copy without any paths
 run_test "Copy without paths" 2 "error_pattern" "required" \
-    python3 "$QMCTL_SCRIPT" cp
+    qmctl cp
 
 # Test 7: Copy with single path (missing destination)
 run_test "Copy with single path" 2 "error_pattern" "required" \
-    python3 "$QMCTL_SCRIPT" cp /some/path
+    qmctl cp /some/path
 
 # Test 8: Copy with invalid path format
 run_test "Copy with invalid path format" 1 "error_pattern" "Provide.*qm.*only in source or destination" \
-    python3 "$QMCTL_SCRIPT" cp /some/path invalid:/path/format
+    qmctl cp /some/path invalid:/path/format
 
 # Test 9: Copy both paths with qm: prefix (invalid)
 run_test "Copy both paths with container prefix" 1 "error_pattern" "Provide.*qm.*only in source or destination" \
-    python3 "$QMCTL_SCRIPT" cp qm:/path1 qm:/path2
+    qmctl cp qm:/path1 qm:/path2
 
 # Test 10: Show with invalid subcommand
 run_test "Show invalid subcommand" 2 "error_pattern" "invalid choice" \
-    python3 "$QMCTL_SCRIPT" show invalid_show_command
+    qmctl show invalid_show_command
 
 # Test 11: Help command (should succeed)
 run_test "Help command" 0 "output_pattern" "usage" \
-    python3 "$QMCTL_SCRIPT" --help
+    qmctl --help
 
 # Test 12: JSON flag with exec but no command
 run_test "JSON exec without command" 22 "none" "" \
-    python3 "$QMCTL_SCRIPT" exec --json
+    qmctl exec --json
 
 # Test 13: Verbose mode with error
 run_test "Verbose mode with error" 22 "error_pattern" "No command provided" \
-    python3 "$QMCTL_SCRIPT" -v exec
+    qmctl -v exec
 
 # Test 14: Empty string as command
 run_test "Empty string command" 1 "error_pattern" "Failed to execute" \
-    python3 "$QMCTL_SCRIPT" exec ""
+    qmctl exec ""
 
 # Test 15: Exec with non-existent command
 run_test "Exec non-existent command" 1 "error_pattern" "not found" \
-    python3 "$QMCTL_SCRIPT" exec /definitely/nonexistent/command/12345
+    qmctl exec /definitely/nonexistent/command/12345
 
 # Test 16: Execin with non-existent nested container
 run_test "Execin non-existent container" 1 "error_pattern" "failed" \
-    python3 "$QMCTL_SCRIPT" execin nonexistent_nested_container echo hello
+    qmctl execin nonexistent_nested_container echo hello
 
 # Test 17: Copy non-existent source file
 nonexistent_file="/tmp/qmctl_test_nonexistent_$(date +%s%N)"
 run_test "Copy non-existent source" 1 "error_pattern" "could not be found" \
-    python3 "$QMCTL_SCRIPT" cp "$nonexistent_file" qm:/tmp/
+    qmctl cp "$nonexistent_file" qm:/tmp/
 
 # Test 18: Very long command
 long_command=$(printf 'a%.0s' {1..1000})
 run_test "Very long command" 1 "error_pattern" "File name too long" \
-    python3 "$QMCTL_SCRIPT" exec "$long_command"
+    qmctl exec "$long_command"
 
 # Test 19: Special characters in command
 # shellcheck disable=SC2016  # Single quotes intentional to prevent expansion
 run_test "Special characters command" 1 "error_pattern" "not found" \
-    python3 "$QMCTL_SCRIPT" exec 'command_with_$pecial_ch@rs_!@#$%^&*()'
+    qmctl exec 'command_with_$pecial_ch@rs_!@#$%^&*()'
 
 # All tests passed
 pass_message "All qmctl error handling tests completed successfully"

--- a/tests/qmctl-test/scripts/qmctl_exec.sh
+++ b/tests/qmctl-test/scripts/qmctl_exec.sh
@@ -3,14 +3,13 @@
 # shellcheck disable=SC1091
 . ../e2e/lib/utils
 
-QMCTL_SCRIPT="../../tools/qmctl/qmctl"
 CONTAINER_NAME="alpine-podman"
 
 # Cleanup function that will be called on script exit
 cleanup() {
-    if python3 $QMCTL_SCRIPT exec test -f /tmp/test_file > /dev/null 2>&1; then
+    if qmctl exec test -f /tmp/test_file > /dev/null 2>&1; then
         info_message "Removing test file..."
-        python3 $QMCTL_SCRIPT exec rm -f /tmp/test_file > /dev/null 2>&1 || true
+        qmctl exec rm -f /tmp/test_file > /dev/null 2>&1 || true
     fi
 }
 
@@ -19,21 +18,21 @@ trap cleanup EXIT
 
 # Cleanup any existing container from previous runs
 info_message "Cleaning up any existing test container..."
-python3 $QMCTL_SCRIPT exec podman rm -f "$CONTAINER_NAME" > /dev/null 2>&1 || true
+qmctl exec podman rm -f "$CONTAINER_NAME" > /dev/null 2>&1 || true
 
 # Create new container
 info_message "Creating test container..."
-python3 $QMCTL_SCRIPT exec podman run -d --name "$CONTAINER_NAME" --replace alpine tail -f /dev/null
+qmctl exec podman run -d --name "$CONTAINER_NAME" --replace alpine tail -f /dev/null
 
 # Verify container was created
-if ! python3 $QMCTL_SCRIPT exec podman ps -a | grep -q "$CONTAINER_NAME"; then
+if ! qmctl exec podman ps -a | grep -q "$CONTAINER_NAME"; then
     fail_message "Container $CONTAINER_NAME was not created"
     exit 1
 fi
 
 # Test that touch command returns exit code 0 with empty output
 info_message "Testing touch command with empty output..."
-touch_output=$(python3 $QMCTL_SCRIPT exec touch /tmp/test_file 2>&1)
+touch_output=$(qmctl exec touch /tmp/test_file 2>&1)
 touch_exit=$?
 
 if [ $touch_exit -ne 0 ]; then

--- a/tests/qmctl-test/scripts/qmctl_execin.sh
+++ b/tests/qmctl-test/scripts/qmctl_execin.sh
@@ -3,39 +3,38 @@
 # shellcheck disable=SC1091
 . ../e2e/lib/utils
 
-QMCTL_SCRIPT="../../tools/qmctl/qmctl"
 CONTAINER_NAME="alpine-podman"
 TMP_FILE="/tmp/file-execin.txt"
 
 # Ensure the alpine-podman container exists (create if needed)
-if ! python3 $QMCTL_SCRIPT exec podman ps -a | grep -q "$CONTAINER_NAME"; then
+if ! qmctl exec podman ps -a | grep -q "$CONTAINER_NAME"; then
     info_message "Creating $CONTAINER_NAME container for execin test..."
-    python3 $QMCTL_SCRIPT exec podman run -d --name "$CONTAINER_NAME" alpine tail -f /dev/null
+    qmctl exec podman run -d --name "$CONTAINER_NAME" alpine tail -f /dev/null
 fi
 
 # Ensure the container is running
-python3 $QMCTL_SCRIPT exec podman start "$CONTAINER_NAME" > /dev/null 2>&1 || true
+qmctl exec podman start "$CONTAINER_NAME" > /dev/null 2>&1 || true
 
 # Clean up any existing test file from previous runs
-python3 $QMCTL_SCRIPT execin "$CONTAINER_NAME" rm -f "$TMP_FILE" > /dev/null 2>&1 || true
+qmctl execin "$CONTAINER_NAME" rm -f "$TMP_FILE" > /dev/null 2>&1 || true
 
 # Verify test file doesn't exist
-if python3 $QMCTL_SCRIPT execin "$CONTAINER_NAME" ls -la /tmp/ | grep -q "file-execin.txt"; then
+if qmctl execin "$CONTAINER_NAME" ls -la /tmp/ | grep -q "file-execin.txt"; then
     fail_message "The file $TMP_FILE still exists after cleanup"
     exit 1
 fi
 
 # Create the test file
 info_message "Testing execin functionality..."
-python3 $QMCTL_SCRIPT execin "$CONTAINER_NAME" touch "$TMP_FILE"
+qmctl execin "$CONTAINER_NAME" touch "$TMP_FILE"
 
 # Verify the file was created and can be read
-if ! python3 $QMCTL_SCRIPT execin "$CONTAINER_NAME" cat "$TMP_FILE" > /dev/null 2>&1; then
+if ! qmctl execin "$CONTAINER_NAME" cat "$TMP_FILE" > /dev/null 2>&1; then
     fail_message "The file $TMP_FILE was not created or cannot be read"
     exit 1
 fi
 
 # Cleanup test file
-python3 $QMCTL_SCRIPT execin "$CONTAINER_NAME" rm -f "$TMP_FILE" > /dev/null 2>&1 || true
+qmctl execin "$CONTAINER_NAME" rm -f "$TMP_FILE" > /dev/null 2>&1 || true
 
 pass_message "qmctl execin command executed successfully"

--- a/tests/qmctl-test/scripts/qmctl_show_variants.sh
+++ b/tests/qmctl-test/scripts/qmctl_show_variants.sh
@@ -6,8 +6,6 @@ set -e
 # shellcheck disable=SC1091
 . ../e2e/lib/utils
 
-QMCTL_SCRIPT="../../tools/qmctl/qmctl"
-
 # Install development tools if needed
 exec_cmd "dnf install --setopt=reposdir=/etc/yum.repos.d  --installroot=/usr/lib/qm/rootfs -y iproute hostname || true"
 
@@ -18,7 +16,7 @@ info_message "Testing: Basic show command (default)"
 expected_output_file="/usr/share/containers/systemd/qm.container"
 actual_output_temp_file=$(mktemp)
 
-python3 "$QMCTL_SCRIPT" show > "$actual_output_temp_file"
+qmctl show > "$actual_output_temp_file"
 
 if diff "$actual_output_temp_file" "$expected_output_file" > /dev/null; then
     pass_message "Basic show - Output matches expected container config"
@@ -32,14 +30,14 @@ fi
 rm -f "$actual_output_temp_file"
 
 # Clean up the basic test file
-python3 "$QMCTL_SCRIPT" exec bash -c "rm -f /tmp/file-to-copy.txt && echo 'cleaned up basic test file'" >/dev/null 2>&1 || true
+qmctl exec bash -c "rm -f /tmp/file-to-copy.txt && echo 'cleaned up basic test file'" >/dev/null 2>&1 || true
 
 # Test 1: Show unix-domain-sockets (handle missing 'ss' command gracefully)
 info_message "Testing: Show unix-domain-sockets"
 unix_sockets_file=$(mktemp)
 stderr_file=$(mktemp)
 
-python3 "$QMCTL_SCRIPT" show unix-domain-sockets > "$unix_sockets_file" 2> "$stderr_file"
+qmctl show unix-domain-sockets > "$unix_sockets_file" 2> "$stderr_file"
 
 unix_sockets_exit=$?
 
@@ -71,20 +69,20 @@ rm -f "$unix_sockets_file" "$stderr_file"
 
 # Test 2: Show shared-memory
 run_test "Show shared-memory" 0 "output_pattern" "Shared Memory Segments" \
-    python3 "$QMCTL_SCRIPT" show shared-memory
+    qmctl show shared-memory
 
 # Test 3: Show available-devices - Contains device info
 run_test "Show available-devices - device pattern" 0 "output_pattern" "present in QM" \
-    python3 "$QMCTL_SCRIPT" show available-devices
+    qmctl show available-devices
 
 # Test 4: Show namespaces
 run_test "Show namespaces" 0 "output_pattern" "Namespaces" \
-    python3 "$QMCTL_SCRIPT" show namespaces
+    qmctl show namespaces
 
 # Test 5: Show all (comprehensive test - handle missing tools gracefully)
 info_message "Testing: Show all"
 show_all_file=$(mktemp)
-timeout 3s python3 "$QMCTL_SCRIPT" show all > "$show_all_file" 2>&1 || true
+timeout 3s qmctl show all > "$show_all_file" 2>&1 || true
 
 # Check that the file contains expected content
 if [ -s "$show_all_file" ]; then
@@ -107,7 +105,7 @@ rm -f "$show_all_file"
 # Test 6: Show resources (special handling - may be interactive)
 info_message "Testing: Show resources (with timeout)"
 show_resources_file=$(mktemp)
-timeout 10s python3 "$QMCTL_SCRIPT" show resources > "$show_resources_file" 2>&1 || true
+timeout 10s qmctl show resources > "$show_resources_file" 2>&1 || true
 
 # Check that the file contains expected content
 if [ -s "$show_resources_file" ]; then

--- a/tests/qmctl-test/test_qmctl.sh
+++ b/tests/qmctl-test/test_qmctl.sh
@@ -5,10 +5,8 @@
 
 info_message "Running qmctl command..."
 
-QMCTL_SCRIPT="../../tools/qmctl/qmctl"
-
-if [ ! -f "$QMCTL_SCRIPT" ]; then
-  fail_message "qmctl script not found at $QMCTL_SCRIPT"
+if ! command -v qmctl &> /dev/null; then
+  fail_message "qmctl command not found in PATH"
   exit 1
 fi
 

--- a/tools/qmctl/__init__.py
+++ b/tools/qmctl/__init__.py
@@ -1,1 +1,5 @@
 """QMCTL package: command-line interface and helpers for QM Controller."""
+
+from qmctl.qmctl import main
+
+__all__ = ["main"]


### PR DESCRIPTION
- Add Python module to qm-ctl package (qmctl.py, __init__.py)
- Update all qmctl test scripts to use installed 'qmctl' command
- Fixes ModuleNotFoundError when using qmctl from RPM installation

closes https://github.com/containers/qm/issues/939

## Summary by Sourcery

Enable qmctl installation as a Python module and update tests and packaging to use the installed qmctl CLI

New Features:
- Package the qmctl command as an importable Python module

Enhancements:
- Refactor all qmctl test scripts to invoke the installed qmctl CLI instead of a local Python script

Build:
- Upgrade RPM specs to version 1.0, add python3-devel BuildRequires, and install qmctl Python module files