### PR TITLE
We are attempting to change selinux option which SHOULD create alert

### DIFF
--- a/tests/ffi/selinux/main.fmf
+++ b/tests/ffi/selinux/main.fmf
@@ -4,3 +4,7 @@ duration: 10m
 tag: ffi
 framework: shell
 id: 0ebfdd87-65ee-4ee9-a3d7-24acaa01ce43
+
+check:
+  - how: avc
+    result: xfail


### PR DESCRIPTION
- adding avc check for this test case
- result: xfail - we want to create avc error and have it logged

## Summary by Sourcery

Tests:
- Introduce an SELinux test case that changes an option to generate an AVC error and verifies it is logged as an expected failure.