### PR TITLE
Add User Namespaces

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -14,7 +14,27 @@ on:
       - 'tools/**'
 
 jobs:
-  test:
+  qm-unit-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.9'
+
+      - name: Install dependencies
+        run: |
+          pip install tmt
+
+      - name: Run QM unit tests
+        run: |
+          tmt --feeling-safe run -v plan --name unit
+
+  qmctl-unit-tests:
     runs-on: ubuntu-latest
     container: python:3.11-slim
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,19 +1,30 @@
-name: Tools Tests
+name: Unit Tests
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - 'tools/**'
-
-  pull_request:
-    branches:
-      - main
-    paths:
-      - 'tools/**'
+  pull_request
 
 jobs:
+
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.9'
+
+      - name: Install dependencies
+        run: |
+          pip install tmt
+
+      - name: Check tmt test IDs
+        run: |
+          tmt test id --dry | grep -q "New id" && { echo "Found integration tests with missing ID. Please generate Test-IDs."; exit 1; } || true
+
   qm-unit-tests:
     runs-on: ubuntu-latest
 
@@ -32,7 +43,7 @@ jobs:
 
       - name: Run QM unit tests
         run: |
-          tmt --feeling-safe run -v plan --name unit
+          tmt --feeling-safe run -vvv plan --name unit
 
   qmctl-unit-tests:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,7 @@ install: man all ##             - Install QM files (including selinux)
 	install -d -m 755 ${DESTDIR}${DATADIR}/qm
 	install -D -m 644 qm_contexts  ${DESTDIR}${DATADIR}/qm/contexts
 	install -D -m 755 setup ${DESTDIR}${DATADIR}/qm/setup
+	install -D -m 755 userns ${DESTDIR}${DATADIR}/qm/userns
 	install -D -m 755 tools/comment-tz-local ${DESTDIR}${DATADIR}/qm/comment-tz-local
 	install -D -m 755 tools/qm-rootfs ${DESTDIR}${DATADIR}/qm/qm-rootfs
 	install -D -m 755 tools/qm-storage-settings ${DESTDIR}${DATADIR}/qm/qm-storage-settings

--- a/docs/docs/getting_started.md
+++ b/docs/docs/getting_started.md
@@ -9,9 +9,30 @@ On Fedora and CentOS-Stream systems (with EPEL repository enabled), QM can be di
 dnf install qm
 ```
 
-## RPM Mirrors
+### RPM Mirrors
 
 Looking for a specific version of QM?
 Search in the mirrors list below.
 
 [CentOS Automotive SIG - qm package - noarch](https://mirror.stream.centos.org/SIGs/9-stream/automotive/aarch64/packages-main/Packages/q/)
+
+## User Namespaces
+
+QM runs without user namespaces by default. The `qm` RPM provides the `userns` tool, which provides support to enable or disable running QM with user namespaces.
+
+```shell
+# Configure QM to run with user namespaces (default values)
+$ /usr/share/qm/userns enable
+
+# ... or use a different UID/GID offset
+$ /usr/share/qm/userns enable --id-offset 4000000000
+```
+
+After enabling it, make sure to reload the systemd units so the service is properly generated from the quadlet file and its drop-in configurations:
+
+```shell
+systemctl daemon-reload
+systemctl restart qm
+```
+
+If everything went well, the `ps` output should now display QM processes with a `qm_` prefix, e.g. `qm_root` or `qm_dbus`.

--- a/plans/unit.fmf
+++ b/plans/unit.fmf
@@ -1,0 +1,15 @@
+summary: Unit tests for QM
+description: Verify that the functionality of QM does not break on a unit level
+
+discover:
+    how: fmf
+    filter: tier:unit
+
+provision:
+    how: local
+
+execute:
+    how: tmt
+
+report:
+    how: junit

--- a/qm.container
+++ b/qm.container
@@ -122,4 +122,3 @@ Timezone=local
 Volume=${RWETCFS}:/etc
 Volume=${RWVARFS}:/var
 Volume=${RWVARFS}/tmp:/var/tmp
-

--- a/rpm/qm.spec
+++ b/rpm/qm.spec
@@ -64,12 +64,13 @@ BuildRequires: selinux-policy-devel >= %_selinux_policy_version
 BuildRequires: bluechi-selinux
 BuildRequires: python3-devel
 
+Recommends: selinux-policy-targeted >= %_selinux_policy_version
+
 Requires: parted
 Requires: containers-common
 Requires: selinux-policy >= %_selinux_policy_version
 Requires(post): selinux-policy-base >= %_selinux_policy_version
 Requires(post): selinux-policy-any >= %_selinux_policy_version
-Recommends: selinux-policy-targeted >= %_selinux_policy_version
 Requires(post): policycoreutils
 Requires(post): libselinux-utils
 Requires: podman >= %{podman_epoch}:4.5
@@ -169,6 +170,7 @@ fi
 %{_datadir}/qm/contexts
 %{_datadir}/qm/file_contexts
 %{_datadir}/qm/setup
+%{_datadir}/qm/userns
 %{_datadir}/qm/create-seccomp-rules
 %{_datadir}/qm/qm-rootfs
 %{_datadir}/qm/qm-storage-settings

--- a/setup
+++ b/setup
@@ -18,8 +18,6 @@ RWETCFS="/etc/qm"
 RWVARFS="/var/qm"
 AGENT_HOSTNAME="$(hostname)"
 AGENTCONF="/etc/bluechi/agent.conf.d/agent.conf"
-QM_CONTAINER_IDS=1000000000:1500000000
-CONTAINER_IDS=2500000000:1500000000
 PACKAGES_TO_INSTALL="selinux-policy-targeted podman systemd procps-ng iptables-nft jq hostname"
 
 # RHEL kernel uses iptables-nft, not iptables-legacy, the tool should
@@ -99,11 +97,6 @@ usage()
    echo "  $ sudo ./setup --installdir=/usr/share/qm --rootfs=/usr/lib/qm/rootfs"
 }
 
-replaceIDs() {
-    touch "$1"
-    grep -q "^$2:" "$1" || echo "$2":"$3" >> "$1"
-}
-
 bluechiSetup() {
     ROOTFS=$1
     RWETCFS=$2
@@ -131,8 +124,10 @@ setupRW() {
     ROOTFS=$1
     RWETCFS=$2
     RWVARFS=$3
+
     mkdir -Z -p "${ROOTFS}/etc" "${ROOTFS}/var"
     mkdir -Z -p "${RWETCFS}" "${RWVARFS}"
+
     mount --bind "${RWETCFS}" "${ROOTFS}/etc"
     mount --bind "${RWVARFS}" "${ROOTFS}/var"
 }
@@ -263,8 +258,6 @@ EOF
     cp "${INSTALLDIR}/containers.conf" "${ROOTFS}/etc/containers/"
     cp "${INSTALLDIR}/contexts" "${ROOTFS}/usr/share/containers/selinux/"
     cp "${INSTALLDIR}/file_contexts" "${ROOTFS}/etc/selinux/targeted/contexts/files/file_contexts"
-    replaceIDs "${ROOTFS}/etc/subuid" containers ${QM_CONTAINER_IDS}
-    replaceIDs "${ROOTFS}/etc/subgid" containers ${QM_CONTAINER_IDS}
     bluechiSetup "${ROOTFS}" "${RWETCFS}" "${RWVARFS}"
 
     if [ "$SYSTEMCTL_SKIP" == "N" ]; then
@@ -376,10 +369,6 @@ case "$1" in
     fi
 
 	install "${ROOTFS}" "${RWETCFS}" "${RWVARFS}"
-	replaceIDs /etc/subuid qmcontainers ${QM_CONTAINER_IDS}
-	replaceIDs /etc/subgid qmcontainers ${QM_CONTAINER_IDS}
-	replaceIDs /etc/subuid containers   ${CONTAINER_IDS}
-	replaceIDs /etc/subgid containers   ${CONTAINER_IDS}
 
     if [ "$SYSTEMCTL_SKIP" == "N" ]; then
 	    systemctl daemon-reload

--- a/tests/qm-kvm-test/kvm-basic/check_container_kvm_run_in_qm.fmf
+++ b/tests/qm-kvm-test/kvm-basic/check_container_kvm_run_in_qm.fmf
@@ -4,6 +4,8 @@ require:
 test: /bin/bash ./check_container_kvm_run_in_qm.sh
 duration: 10m
 tier: 0
-tag: [kvm,setup]
+tag:
+  - kvm
+  - setup
 framework: shell
-
+id: 7552c7aa-5384-4ee3-bee7-33ce09bf1c72

--- a/tests/qm-kvm-test/libkrun/check_libkrun.fmf
+++ b/tests/qm-kvm-test/libkrun/check_libkrun.fmf
@@ -2,6 +2,8 @@ summary: Test libkrun in qm
 test: /bin/bash ./check_libkrun.sh
 duration: 10m
 tier: 0
-tag: [kvm,setup]
+tag:
+  - kvm
+  - setup
 framework: shell
-
+id: b5e2b341-98f5-4936-9d73-6ae114f0e685

--- a/tests/qm-sanity-test/check_qm_podman_ulimits_are_set.fmf
+++ b/tests/qm-sanity-test/check_qm_podman_ulimits_are_set.fmf
@@ -2,7 +2,9 @@ summary: Test podman ulimits qm are set
 test: /bin/bash ./check_qm_podman_ulimits_are_set.sh
 duration: 10m
 tier: 0
-tag: [kvm,setup]
-#Need to run first for Fedora use case
+tag:
+  - kvm
+  - setup
 order: 40
 framework: shell
+id: 78464d0f-1e8f-4601-8651-5412ce6bb8bf

--- a/tests/userns/main.fmf
+++ b/tests/userns/main.fmf
@@ -1,11 +1,12 @@
 tier: unit
 summary: Unit tests for userns script functions
 description: |
-  Tests individual functions in the userns script including:
-  - generate_sysusers_conf
-  - generate_qm_dropin
-  - add_subid_entries
-  - remove_subid_entries
-  - enable and disable orchestration functions
+    Tests individual functions in the userns script including:
+    - generate_sysusers_conf
+    - generate_qm_dropin
+    - add_subid_entries
+    - remove_subid_entries
+    - enable and disable orchestration functions
 test: ./test.sh
 duration: 5m
+id: 4bdb1f93-f339-48a8-858e-b75ad5f834b6

--- a/tests/userns/main.fmf
+++ b/tests/userns/main.fmf
@@ -1,0 +1,11 @@
+tier: unit
+summary: Unit tests for userns script functions
+description: |
+  Tests individual functions in the userns script including:
+  - generate_sysusers_conf
+  - generate_qm_dropin
+  - add_subid_entries
+  - remove_subid_entries
+  - enable and disable orchestration functions
+test: ./test.sh
+duration: 5m

--- a/tests/userns/test.sh
+++ b/tests/userns/test.sh
@@ -1,0 +1,638 @@
+#!/bin/bash -uxv
+# shellcheck disable=SC1090,SC1091,SC2317,SC2155
+#
+# Unit tests for userns script functions
+# Tests each function in isolation with mock data to avoid system modifications
+#
+
+# Source utilities
+source ../e2e/lib/utils
+
+# Relative path to userns script
+USERNS_SCRIPT="../../userns"
+
+# Global test variables
+TEST_DIR=""
+MOCK_ROOT_DIR=""
+MOCK_SYSUSERS_DIR=""
+MOCK_DROPIN_DIR=""
+TEST_PASSED=0
+TEST_FAILED=0
+
+# Test configuration
+USERMOD_CALLS=()
+SYSTEMD_SYSUSERS_CALLED=0
+
+#######################################
+# Setup test environment
+# Creates temporary directories and mock files
+#######################################
+setup_test_env() {
+    info_message "Setting up test environment"
+    TEST_DIR=$(mktemp -d -t userns-test.XXXXXX)
+    MOCK_ROOT_DIR="${TEST_DIR}/etc"
+    MOCK_SYSUSERS_DIR="${TEST_DIR}/sysusers.d"
+    MOCK_DROPIN_DIR="${TEST_DIR}/dropin"
+
+    mkdir -p "${MOCK_ROOT_DIR}"
+    mkdir -p "${MOCK_SYSUSERS_DIR}"
+    mkdir -p "${MOCK_DROPIN_DIR}"
+
+    info_message "Test directory created at ${TEST_DIR}"
+}
+
+#######################################
+# Cleanup test environment
+# Removes all temporary files and directories
+#######################################
+cleanup_test_env() {
+    if [ -n "${TEST_DIR}" ] && [ -d "${TEST_DIR}" ]; then
+        info_message "Cleaning up test directory ${TEST_DIR}"
+        rm -rf "${TEST_DIR}"
+    fi
+}
+
+# Register cleanup trap
+trap cleanup_test_env EXIT
+
+#######################################
+# Create mock /etc/passwd file
+# Arguments:
+#   $1 - Path to output file
+#######################################
+create_mock_passwd() {
+    local output_file="$1"
+    cat > "${output_file}" << 'EOF'
+root:x:0:0:root:/root:/bin/bash
+daemon:x:1:1:daemon:/usr/sbin:/usr/sbin/nologin
+bin:x:2:2:bin:/bin:/usr/sbin/nologin
+sys:x:3:3:sys:/dev:/usr/sbin/nologin
+sync:x:4:65534:sync:/bin:/bin/sync
+testuser:x:1000:1000:Test User:/home/testuser:/bin/bash
+nobody:x:65534:65534:nobody:/nonexistent:/usr/sbin/nologin
+EOF
+}
+
+#######################################
+# Create mock /etc/group file
+# Arguments:
+#   $1 - Path to output file
+#######################################
+create_mock_group() {
+    local output_file="$1"
+    cat > "${output_file}" << 'EOF'
+root:x:0:
+daemon:x:1:
+bin:x:2:
+sys:x:3:
+adm:x:4:
+tty:x:5:
+disk:x:6:
+testgroup:x:1000:
+users:x:100:
+nogroup:x:65534:
+EOF
+}
+
+#######################################
+# Create mock /etc/subuid and /etc/subgid files
+# Arguments:
+#   $1 - Path to subuid file
+#   $2 - Path to subgid file
+#######################################
+create_mock_subid_files() {
+    local subuid_file="$1"
+    local subgid_file="$2"
+
+    cat > "${subuid_file}" << 'EOF'
+root:100000:65536
+testuser:165536:65536
+existing_user:231072:65536
+EOF
+
+    cat > "${subgid_file}" << 'EOF'
+root:100000:65536
+testuser:165536:65536
+existing_user:231072:65536
+EOF
+}
+
+#######################################
+# Mock usermod command
+# Records calls instead of actually running usermod
+#######################################
+usermod() {
+    USERMOD_CALLS+=("$*")
+    info_message "MOCK: usermod $*"
+}
+
+#######################################
+# Mock systemd-sysusers command
+#######################################
+systemd-sysusers() {
+    ((SYSTEMD_SYSUSERS_CALLED++))
+    info_message "MOCK: systemd-sysusers called"
+}
+
+#######################################
+# Verify sysusers configuration file format
+# Arguments:
+#   $1 - Path to sysusers config file
+# Returns:
+#   0 if valid, 1 if invalid
+#######################################
+verify_sysusers_format() {
+    local config_file="$1"
+
+    if [ ! -f "${config_file}" ]; then
+        fail_message "Config file ${config_file} does not exist"
+        return 1
+    fi
+
+    local line_count=$(wc -l < "${config_file}")
+    if [ "${line_count}" -eq 0 ]; then
+        fail_message "Config file is empty"
+        return 1
+    fi
+
+    # Check for expected format: "u     qm_username      UID:GID" for users (with multiple spaces)
+    # and "g     qm_groupname     GID" for groups
+    # Also skip comment lines starting with #
+    local user_pattern='^u[[:space:]]+qm_[a-z0-9_-]+[[:space:]]+[0-9]+:[0-9]+[[:space:]]+".*"$'
+    local group_pattern='^g[[:space:]]+qm_[a-z0-9_-]+[[:space:]]+[0-9]+$'
+    local comment_pattern='^#'
+
+    while IFS= read -r line; do
+        # Skip comment lines
+        if [[ "${line}" =~ ${comment_pattern} ]]; then
+            continue
+        fi
+        if [[ ! "${line}" =~ ${user_pattern} ]] && [[ ! "${line}" =~ ${group_pattern} ]]; then
+            fail_message "Invalid line format: ${line}"
+            return 1
+        fi
+    done < "${config_file}"
+
+    return 0
+}
+
+#######################################
+# Record test result
+# Arguments:
+#   $1 - Test name
+#   $2 - Result (0 for pass, non-zero for fail)
+#######################################
+record_test_result() {
+    local test_name="$1"
+    local result="$2"
+
+    if [ "${result}" -eq 0 ]; then
+        pass_message "PASS: ${test_name}"
+        ((TEST_PASSED++))
+    else
+        fail_message "FAIL: ${test_name}"
+        ((TEST_FAILED++))
+    fi
+}
+
+#######################################
+# Test: generate_sysusers_conf with basic input
+#######################################
+test_generate_sysusers_conf_basic() {
+    info_message "TEST: generate_sysusers_conf - basic functionality"
+
+    # Setup
+    local passwd_file="${MOCK_ROOT_DIR}/passwd"
+    local group_file="${MOCK_ROOT_DIR}/group"
+    local output_file="${MOCK_SYSUSERS_DIR}/test-output.conf"
+
+    create_mock_passwd "${passwd_file}"
+    create_mock_group "${group_file}"
+
+    # Source the userns script to get the function
+    source "${USERNS_SCRIPT}"
+
+    # Execute
+    generate_sysusers_conf "${MOCK_ROOT_DIR}" "${output_file}" 1000000000
+
+    # Verify
+    local result=0
+    if ! verify_sysusers_format "${output_file}"; then
+        result=1
+    fi
+
+    # Check that root user is transformed correctly (allowing for whitespace)
+    if ! grep -q "qm_root[[:space:]]\+1000000000:1000000000" "${output_file}"; then
+        fail_message "Root user not found with correct UID:GID"
+        result=1
+    fi
+
+    # Check that testuser is transformed correctly (UID 1000 + offset)
+    if ! grep -q "qm_testuser[[:space:]]\+1000001000:1000001000" "${output_file}"; then
+        fail_message "testuser not found with correct UID:GID"
+        result=1
+    fi
+
+    # Check that groups are created
+    if ! grep -q "qm_root[[:space:]]\+1000000000" "${output_file}"; then
+        fail_message "Root group not found"
+        result=1
+    fi
+
+    record_test_result "generate_sysusers_conf_basic" "${result}"
+    return "${result}"
+}
+
+#######################################
+# Test: generate_sysusers_conf with custom offset
+#######################################
+test_generate_sysusers_conf_custom_offset() {
+    info_message "TEST: generate_sysusers_conf - custom offset"
+
+    # Setup
+    local passwd_file="${MOCK_ROOT_DIR}/passwd"
+    local group_file="${MOCK_ROOT_DIR}/group"
+    local output_file="${MOCK_SYSUSERS_DIR}/test-offset.conf"
+
+    create_mock_passwd "${passwd_file}"
+    create_mock_group "${group_file}"
+
+    # Source the userns script
+    source "${USERNS_SCRIPT}"
+
+    # Execute with different offset
+    local custom_offset=5000000000
+    generate_sysusers_conf "${MOCK_ROOT_DIR}" "${output_file}" "${custom_offset}"
+
+    # Verify
+    local result=0
+
+    # Check that root user has custom offset applied
+    if ! grep -q "qm_root[[:space:]]\+${custom_offset}:${custom_offset}" "${output_file}"; then
+        fail_message "Root user not found with custom offset"
+        result=1
+    fi
+
+    # Check that testuser has custom offset applied (1000 + 5000000000)
+    local expected_uid=$((1000 + custom_offset))
+    if ! grep -q "qm_testuser[[:space:]]\+${expected_uid}:${expected_uid}" "${output_file}"; then
+        fail_message "testuser not found with custom offset (expected ${expected_uid})"
+        result=1
+    fi
+
+    record_test_result "generate_sysusers_conf_custom_offset" "${result}"
+    return "${result}"
+}
+
+#######################################
+# Test: generate_sysusers_conf preserves GECOS field
+#######################################
+test_generate_sysusers_conf_gecos() {
+    info_message "TEST: generate_sysusers_conf - GECOS preservation"
+
+    # Setup
+    local passwd_file="${MOCK_ROOT_DIR}/passwd"
+    local group_file="${MOCK_ROOT_DIR}/group"
+    local output_file="${MOCK_SYSUSERS_DIR}/test-gecos.conf"
+
+    create_mock_passwd "${passwd_file}"
+    create_mock_group "${group_file}"
+
+    # Source the userns script
+    source "${USERNS_SCRIPT}"
+
+    # Execute
+    generate_sysusers_conf "${MOCK_ROOT_DIR}" "${output_file}" 1000000000
+
+    # Verify
+    local result=0
+
+    # Check that GECOS field is preserved with "QM - " prefix
+    if ! grep -q 'qm_testuser[[:space:]]\+[0-9]\+:[0-9]\+[[:space:]]\+"QM - Test User"' "${output_file}"; then
+        fail_message "GECOS field not properly preserved for testuser"
+        result=1
+    fi
+
+    if ! grep -q 'qm_root[[:space:]]\+[0-9]\+:[0-9]\+[[:space:]]\+"QM - root"' "${output_file}"; then
+        fail_message "GECOS field not properly preserved for root"
+        result=1
+    fi
+
+    record_test_result "generate_sysusers_conf_gecos" "${result}"
+    return "${result}"
+}
+
+#######################################
+# Test: generate_qm_dropin basic functionality
+#######################################
+test_generate_qm_dropin_basic() {
+    info_message "TEST: generate_qm_dropin - basic functionality"
+
+    # Setup
+    local dropin_file="${MOCK_DROPIN_DIR}/test-dropin.conf"
+    local test_user="qm_root"
+
+    # Source the userns script
+    source "${USERNS_SCRIPT}"
+
+    # Execute
+    generate_qm_dropin "${dropin_file}" "${test_user}"
+
+    # Verify
+    local result=0
+
+    if [ ! -f "${dropin_file}" ]; then
+        fail_message "Dropin file was not created"
+        result=1
+    fi
+
+    if ! grep -q "^SubUIDMap=${test_user}$" "${dropin_file}"; then
+        fail_message "SubUIDMap not set correctly"
+        result=1
+    fi
+
+    if ! grep -q "^SubGIDMap=${test_user}$" "${dropin_file}"; then
+        fail_message "SubGIDMap not set correctly"
+        result=1
+    fi
+
+    record_test_result "generate_qm_dropin_basic" "${result}"
+    return "${result}"
+}
+
+#######################################
+# Test: generate_qm_dropin with different username
+#######################################
+test_generate_qm_dropin_custom_user() {
+    info_message "TEST: generate_qm_dropin - custom username"
+
+    # Setup
+    local dropin_file="${MOCK_DROPIN_DIR}/test-dropin-custom.conf"
+    local test_user="custom_user_123"
+
+    # Source the userns script
+    source "${USERNS_SCRIPT}"
+
+    # Execute
+    generate_qm_dropin "${dropin_file}" "${test_user}"
+
+    # Verify
+    local result=0
+
+    if ! grep -q "^SubUIDMap=${test_user}$" "${dropin_file}"; then
+        fail_message "SubUIDMap not set to custom username"
+        result=1
+    fi
+
+    if ! grep -q "^SubGIDMap=${test_user}$" "${dropin_file}"; then
+        fail_message "SubGIDMap not set to custom username"
+        result=1
+    fi
+
+    record_test_result "generate_qm_dropin_custom_user" "${result}"
+    return "${result}"
+}
+
+#######################################
+# Test: add_subid_entries with new user
+# Note: This tests the logic by verifying parameter calculation,
+# but uses mock usermod to avoid system modifications
+#######################################
+test_add_subid_entries_new_user() {
+    info_message "TEST: add_subid_entries - new user"
+
+    # Create a test wrapper that mimics add_subid_entries but with testable paths
+    test_add_subid_entries_impl() {
+        local id_range_start=$1
+        local id_range=$2
+        local id_range_end=$((id_range_start+id_range))
+        local user=$3
+        local subuid_file="${MOCK_ROOT_DIR}/subuid"
+        local subgid_file="${MOCK_ROOT_DIR}/subgid"
+
+        if ! grep -q "^${user}:" "${subuid_file}" 2>/dev/null; then
+            usermod --add-subuids "${id_range_start}-${id_range_end}" "${user}"
+        fi
+        if ! grep -q "^${user}:" "${subgid_file}" 2>/dev/null; then
+            usermod --add-subgids "${id_range_start}-${id_range_end}" "${user}"
+        fi
+    }
+
+    # Setup
+    local subuid_file="${MOCK_ROOT_DIR}/subuid"
+    local subgid_file="${MOCK_ROOT_DIR}/subgid"
+    create_mock_subid_files "${subuid_file}" "${subgid_file}"
+
+    # Reset mock tracking
+    USERMOD_CALLS=()
+
+    # Execute - add entries for a new user
+    test_add_subid_entries_impl 1000000000 1500000000 "new_user"
+
+    # Verify
+    local result=0
+
+    # Should have called usermod twice (once for subuids, once for subgids)
+    if [ "${#USERMOD_CALLS[@]}" -ne 2 ]; then
+        fail_message "Expected 2 usermod calls, got ${#USERMOD_CALLS[@]}"
+        result=1
+    fi
+
+    # Check that usermod was called with correct arguments
+    local expected_range="1000000000-2500000000"
+    if ! echo "${USERMOD_CALLS[0]}" | grep -q -- "--add-subuids ${expected_range} new_user"; then
+        fail_message "usermod not called with correct subuids range"
+        result=1
+    fi
+
+    if ! echo "${USERMOD_CALLS[1]}" | grep -q -- "--add-subgids ${expected_range} new_user"; then
+        fail_message "usermod not called with correct subgids range"
+        result=1
+    fi
+
+    record_test_result "add_subid_entries_new_user" "${result}"
+    return "${result}"
+}
+
+#######################################
+# Test: add_subid_entries idempotency (existing user)
+#######################################
+test_add_subid_entries_existing_user() {
+    info_message "TEST: add_subid_entries - existing user (idempotency)"
+
+    # Create a test wrapper that mimics add_subid_entries but with testable paths
+    test_add_subid_entries_existing_impl() {
+        local id_range_start=$1
+        local id_range=$2
+        local id_range_end=$((id_range_start+id_range))
+        local user=$3
+        local subuid_file="${MOCK_ROOT_DIR}/subuid"
+        local subgid_file="${MOCK_ROOT_DIR}/subgid"
+
+        if ! grep -q "^${user}:" "${subuid_file}" 2>/dev/null; then
+            usermod --add-subuids "${id_range_start}-${id_range_end}" "${user}"
+        fi
+        if ! grep -q "^${user}:" "${subgid_file}" 2>/dev/null; then
+            usermod --add-subgids "${id_range_start}-${id_range_end}" "${user}"
+        fi
+    }
+
+    # Setup
+    local subuid_file="${MOCK_ROOT_DIR}/subuid"
+    local subgid_file="${MOCK_ROOT_DIR}/subgid"
+    create_mock_subid_files "${subuid_file}" "${subgid_file}"
+
+    # Reset mock tracking
+    USERMOD_CALLS=()
+
+    # Execute - try to add entries for existing user
+    test_add_subid_entries_existing_impl 100000 65536 "testuser"
+
+    # Verify
+    local result=0
+
+    # Should NOT have called usermod since user already exists
+    if [ "${#USERMOD_CALLS[@]}" -ne 0 ]; then
+        fail_message "Expected 0 usermod calls for existing user, got ${#USERMOD_CALLS[@]}"
+        result=1
+    fi
+
+    record_test_result "add_subid_entries_existing_user" "${result}"
+    return "${result}"
+}
+
+#######################################
+# Test: remove_subid_entries basic functionality
+#######################################
+test_remove_subid_entries_basic() {
+    info_message "TEST: remove_subid_entries - basic functionality"
+
+    # Create a test wrapper that mimics remove_subid_entries but with testable paths
+    test_remove_subid_entries_impl() {
+        local user=$1
+        local subuid_file="${MOCK_ROOT_DIR}/subuid"
+        local subgid_file="${MOCK_ROOT_DIR}/subgid"
+        sed -i "/^${user}:/d" "${subuid_file}"
+        sed -i "/^${user}:/d" "${subgid_file}"
+    }
+
+    # Setup
+    local subuid_file="${MOCK_ROOT_DIR}/subuid"
+    local subgid_file="${MOCK_ROOT_DIR}/subgid"
+    create_mock_subid_files "${subuid_file}" "${subgid_file}"
+
+    # Execute - remove testuser entries
+    test_remove_subid_entries_impl "testuser"
+
+    # Verify
+    local result=0
+
+    # Check that testuser was removed from subuid
+    if grep -q "^testuser:" "${subuid_file}"; then
+        fail_message "testuser still present in ${subuid_file}"
+        result=1
+    fi
+
+    # Check that testuser was removed from subgid
+    if grep -q "^testuser:" "${subgid_file}"; then
+        fail_message "testuser still present in ${subgid_file}"
+        result=1
+    fi
+
+    # Check that other users remain
+    if ! grep -q "^root:" "${subuid_file}"; then
+        fail_message "root was incorrectly removed from ${subuid_file}"
+        result=1
+    fi
+
+    if ! grep -q "^existing_user:" "${subuid_file}"; then
+        fail_message "existing_user was incorrectly removed from ${subuid_file}"
+        result=1
+    fi
+
+    record_test_result "remove_subid_entries_basic" "${result}"
+    return "${result}"
+}
+
+#######################################
+# Test: remove_subid_entries with non-existent user
+#######################################
+test_remove_subid_entries_nonexistent() {
+    info_message "TEST: remove_subid_entries - non-existent user"
+
+    # Create a test wrapper that mimics remove_subid_entries but with testable paths
+    test_remove_subid_entries_nonexistent_impl() {
+        local user=$1
+        local subuid_file="${MOCK_ROOT_DIR}/subuid"
+        local subgid_file="${MOCK_ROOT_DIR}/subgid"
+        sed -i "/^${user}:/d" "${subuid_file}"
+        sed -i "/^${user}:/d" "${subgid_file}"
+    }
+
+    # Setup
+    local subuid_file="${MOCK_ROOT_DIR}/subuid"
+    local subgid_file="${MOCK_ROOT_DIR}/subgid"
+    create_mock_subid_files "${subuid_file}" "${subgid_file}"
+
+    # Count lines before
+    local subuid_lines_before=$(wc -l < "${subuid_file}")
+    local subgid_lines_before=$(wc -l < "${subgid_file}")
+
+    # Execute - try to remove non-existent user (should not error)
+    test_remove_subid_entries_nonexistent_impl "nonexistent_user"
+
+    # Verify
+    local result=0
+
+    # Check that file contents haven't changed
+    local subuid_lines_after=$(wc -l < "${subuid_file}")
+    local subgid_lines_after=$(wc -l < "${subgid_file}")
+
+    if [ "${subuid_lines_before}" -ne "${subuid_lines_after}" ]; then
+        fail_message "subuid file was modified when removing non-existent user"
+        result=1
+    fi
+
+    if [ "${subgid_lines_before}" -ne "${subgid_lines_after}" ]; then
+        fail_message "subgid file was modified when removing non-existent user"
+        result=1
+    fi
+
+    record_test_result "remove_subid_entries_nonexistent" "${result}"
+    return "${result}"
+}
+
+#######################################
+# Main test execution
+#######################################
+main() {
+    info_message "=== Starting userns unit tests ==="
+
+    # Setup environment
+    setup_test_env
+
+    # Run all tests
+    test_generate_sysusers_conf_basic
+    test_generate_sysusers_conf_custom_offset
+    test_generate_sysusers_conf_gecos
+    test_generate_qm_dropin_basic
+    test_generate_qm_dropin_custom_user
+    test_add_subid_entries_new_user
+    test_add_subid_entries_existing_user
+    test_remove_subid_entries_basic
+    test_remove_subid_entries_nonexistent
+
+    # Summary
+    info_message "=== Test Summary ==="
+    pass_message "Tests passed: ${TEST_PASSED}"
+    if [ "${TEST_FAILED}" -gt 0 ]; then
+        fail_message "Tests failed: ${TEST_FAILED}"
+        exit 1
+    else
+        pass_message "All tests passed!"
+        exit 0
+    fi
+}
+
+# Run tests
+main

--- a/userns
+++ b/userns
@@ -1,0 +1,227 @@
+#!/bin/bash
+
+USAGE_HEADER=$(cat <<EOF
+Generate QM sysusers configuration for the root partition based on users and groups
+inside of QM with an given offset. This maps processes run by users inside of QM to
+the respective qm_<user> on the root partition.
+It also generates the necessary user namespace entries in /etc/subuid and /etc/subgid
+as well as the drop-in file for QM to use the user namespace.
+
+EOF
+)
+
+# Default values for user namespace settings
+ROOT_DIR="/etc"
+ID_OFFSET=1000000000
+ID_RANGE=1500000000
+SYSUSERS_OUTPUT_DIR="/etc/sysusers.d"
+SYSUSERS_CONF_FILE="qm-sysusers.conf"
+QM_DROPIN_DIR="/etc/containers/systemd/qm.container.d"
+QM_DROPIN_FILE="qm-user-namespaces.conf"
+
+
+function generate_sysusers_conf() {
+    local root_dir="${1}"
+    local outfile="${2}"
+    local id_offset=$3
+
+    echo "# Type        Name        ID      GECOS       Home directory      Shell" > "${outfile}"
+    # shellcheck disable=SC2034
+    while IFS=: read -r username password uid gid gecos home shell; do
+        new_uid=$((id_offset+uid))
+        new_gid=$((id_offset+gid))
+        echo "u     qm_${username}      ${new_uid}:${new_gid}       \"QM - ${gecos}\""
+    done < "${root_dir}/passwd" >> "${outfile}"
+
+    # shellcheck disable=SC2034
+    while IFS=: read -r group password gid members; do
+        new_gid=$((id_offset+gid))
+        echo "g     qm_${group}     ${new_gid}"
+    done < "${root_dir}/group" >> "${outfile}"
+}
+
+function generate_qm_dropin() {
+    local file_path=$1
+    local user=$2
+
+    cat > "${file_path}" <<EOF
+# Run the QM container in the user namespace qm using the map with name in the /etc/subgid file.
+# It also maps to the QM user created via systemd sysusers.
+SubUIDMap=${user}
+SubGIDMap=${user}
+EOF
+}
+
+function add_subid_entries() {
+    local id_range_start=$1
+    local id_range=$2
+    local id_range_end=$((id_range_start+id_range))
+    local user=$3
+
+    if ! grep -q "^${user}:" /etc/subuid 2>/dev/null; then
+        usermod --add-subuids "${id_range_start}-${id_range_end}" "${user}"
+    fi
+    if ! grep -q "^{user}:" /etc/subgid 2>/dev/null; then
+        usermod --add-subgids "${id_range_start}-${id_range_end}" "${user}"
+    fi
+}
+
+function enable() {
+    # shellcheck disable=SC2155
+    local SETUP_USAGE=$(cat <<EOF
+${USAGE_HEADER}
+
+Usage:
+    $(basename "${0}") enable [options]
+
+Available options:
+    --root-dir      The root directory where passwd and group are located. Default: '${ROOT_DIR}'.
+    --sysusers-dir  Directory the '${SYSUSERS_CONF_FILE}' is being placed. Default: '${SYSUSERS_OUTPUT_DIR}'.
+    --id-offset     UID/GID offset to be applied. Default: '${ID_OFFSET}'.
+    --id-range      Number of UIDs/GIDs reserved for the QM user namespace. Default: '${ID_RANGE}'.
+
+Flags:
+    -h, --help  Print help
+EOF
+)
+
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --root-dir)
+                ROOT_DIR="${2}"
+                shift 2
+                ;;
+            --sysusers-dir)
+                SYSUSERS_OUTPUT_DIR="${2}"
+                shift 2
+                ;;
+            --id-offset)
+                ID_OFFSET="${2}"
+                shift 2
+                ;;
+            --id-range)
+                ID_RANGE="${2}"
+                shift 2
+                ;;
+            -h|--help)
+                echo "$SETUP_USAGE"
+                exit 0
+                ;;
+            --*)
+                echo "Unknown option $1"
+                echo
+                echo "$SETUP_USAGE"
+                exit 1
+                ;;
+            *)
+                echo "Unknown command: $1"
+                echo
+                echo "$SETUP_USAGE"
+                exit 1
+                ;;
+        esac
+    done
+
+    # Generate sysusers configuration and trigger systemd-sysusers so that
+    # users are created (required by adding subids)
+    local SYSUSERS_CONF_PATH="${SYSUSERS_OUTPUT_DIR}/${SYSUSERS_CONF_FILE}"
+    generate_sysusers_conf "${ROOT_DIR}" "${SYSUSERS_CONF_PATH}" "${ID_OFFSET}"
+    echo "Created '${SYSUSERS_CONF_PATH}'"
+    systemd-sysusers
+
+    # Add subuids/subgids
+    # A root user is always expected, so the corresponding qm user is qm_root
+    add_subid_entries "${ID_OFFSET}" "${ID_RANGE}" "qm_root"
+
+    # Add SubUIDMap= and SubGIDMap= to QM via drop-in
+    local QM_DROPIN_PATH="${QM_DROPIN_DIR}/${QM_DROPIN_FILE}"
+    generate_qm_dropin "${QM_DROPIN_PATH}" "qm_root"
+    echo "Created '${QM_DROPIN_PATH}'"
+}
+
+
+function remove_subid_entries() {
+    local user=$1
+    sed -i "/^${user}:/d" /etc/subuid
+    sed -i "/^${user}:/d" /etc/subgid
+}
+
+
+function disable() {
+    # shellcheck disable=SC2155
+    local SETUP_USAGE=$(cat <<EOF
+${USAGE_HEADER}
+
+Usage:
+    $(basename "${0}") disable [options]
+
+Available options:
+    --sysusers-dir  Directory the '${SYSUSERS_CONF_FILE}' is located. Default: '${SYSUSERS_OUTPUT_DIR}'.
+
+Flags:
+    -h, --help  Print help
+EOF
+)
+
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --sysusers-dir)
+                SYSUSERS_OUTPUT_DIR="${2}"
+                shift 2
+                ;;
+            -h|--help)
+                echo "$SETUP_USAGE"
+                exit 0
+                ;;
+            --*)
+                echo "Unknown option $1"
+                echo
+                echo "$SETUP_USAGE"
+                exit 1
+                ;;
+            *)
+                echo "Unknown command: $1"
+                echo
+                echo "$SETUP_USAGE"
+                exit 1
+                ;;
+        esac
+    done
+
+    remove_subid_entries "qm_root"
+    rm -f "${QM_DROPIN_DIR}/${QM_DROPIN_FILE}"
+    rm -f "${SYSUSERS_OUTPUT_DIR}/${SYSUSERS_CONF_FILE}"
+}
+
+BASIC_USAGE=$(cat <<EOF
+${USAGE_HEADER}
+
+Usage:
+    $(basename "${0}") [enable|disable] [options]
+
+Flags:
+    -h, --help  Print help
+EOF
+)
+case $1 in
+    enable)
+        shift
+        enable "$@"
+        exit 0
+        ;;
+    disable)
+        shift
+        disable "$@"
+        exit 0
+        ;;
+    -h|--help)
+        echo "${BASIC_USAGE}"
+        exit 0
+        ;;
+    *)
+        echo "No or unknown positional argument"
+        echo
+        echo "${BASIC_USAGE}"
+        exit 1
+        ;;
+esac

--- a/userns
+++ b/userns
@@ -61,7 +61,7 @@ function add_subid_entries() {
     if ! grep -q "^${user}:" /etc/subuid 2>/dev/null; then
         usermod --add-subuids "${id_range_start}-${id_range_end}" "${user}"
     fi
-    if ! grep -q "^{user}:" /etc/subgid 2>/dev/null; then
+    if ! grep -q "^${user}:" /etc/subgid 2>/dev/null; then
         usermod --add-subgids "${id_range_start}-${id_range_end}" "${user}"
     fi
 }
@@ -193,7 +193,12 @@ EOF
     rm -f "${SYSUSERS_OUTPUT_DIR}/${SYSUSERS_CONF_FILE}"
 }
 
-BASIC_USAGE=$(cat <<EOF
+
+# Only parse CLI options etc. when invoked directly
+# Do nothing when sourced
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+
+    BASIC_USAGE=$(cat <<EOF
 ${USAGE_HEADER}
 
 Usage:
@@ -203,25 +208,27 @@ Flags:
     -h, --help  Print help
 EOF
 )
-case $1 in
-    enable)
-        shift
-        enable "$@"
-        exit 0
-        ;;
-    disable)
-        shift
-        disable "$@"
-        exit 0
-        ;;
-    -h|--help)
-        echo "${BASIC_USAGE}"
-        exit 0
-        ;;
-    *)
-        echo "No or unknown positional argument"
-        echo
-        echo "${BASIC_USAGE}"
-        exit 1
-        ;;
-esac
+    case $1 in
+        enable)
+            shift
+            enable "$@"
+            exit 0
+            ;;
+        disable)
+            shift
+            disable "$@"
+            exit 0
+            ;;
+        -h|--help)
+            echo "${BASIC_USAGE}"
+            exit 0
+            ;;
+        *)
+            echo "No or unknown positional argument"
+            echo
+            echo "${BASIC_USAGE}"
+            exit 1
+            ;;
+    esac
+
+fi


### PR DESCRIPTION
This PR adds the support for running QM with User Namespaces. For this, it 
- adds a systemd sysusers configuration to set up qm-specific users on the host, 
- adds the `SubUIDMap` and `SubGIDMap` to the quadlet, 
- and creates the necessary entries in `/etc/subuid` and `/etc/subgid` during the post-install phase of the RPM install

~It also removes the tz workaround since the issues to fix it are resolved:~
- ~https://github.com/containers/qm/issues/367~
- ~https://github.com/containers/qm/issues/394~

## Summary by Sourcery

Add qm-specific system users and user namespace mappings to support running QM with user namespaces, and clean up obsolete timezone workaround tooling.

Enhancements:
- Introduce a qm-sysusers configuration defining qm-specific users and groups with fixed IDs for user namespace operation.

Build:
- Update RPM spec to install a systemd sysusers configuration for qm-specific users and manage subuid/subgid ranges for qm_root during post-install and uninstall.
- Adjust RPM dependencies to include shadow-utils for user management and tweak SELinux policy-related requirements.

Chores:
- Remove the comment-tz-local script and its RPM packaging references now that the underlying timezone issues are resolved.

## Summary by Sourcery

Add packaging support for QM to run with dedicated user and group namespaces managed via systemd-sysusers and subuid/subgid mappings.

New Features:
- Define QM-specific system users and groups via a systemd sysusers configuration to back user-namespace-based execution.
- Provision subuid and subgid ranges for the qm_root user during RPM post-install to enable user namespaces.

Enhancements:
- Update the RPM spec to bump the package version and ensure required tools (e.g. shadow-utils) are available for user management.