### PR TITLE
Add root dirs to userns

### DIFF
--- a/tests/userns/test.sh
+++ b/tests/userns/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -uxv
-# shellcheck disable=SC1090,SC1091,SC2317,SC2155
+# shellcheck disable=SC1090,SC1091,SC2317,SC2155,SC2034
 #
 # Unit tests for userns script functions
 # Tests each function in isolation with mock data to avoid system modifications
@@ -16,6 +16,8 @@ TEST_DIR=""
 MOCK_ROOT_DIR=""
 MOCK_SYSUSERS_DIR=""
 MOCK_DROPIN_DIR=""
+SYSUSERS_CONF="qm-sysusers.conf"
+QM_CONF="qm-user-namespaces.conf"
 TEST_PASSED=0
 TEST_FAILED=0
 
@@ -30,13 +32,18 @@ SYSTEMD_SYSUSERS_CALLED=0
 setup_test_env() {
     info_message "Setting up test environment"
     TEST_DIR=$(mktemp -d -t userns-test.XXXXXX)
-    MOCK_ROOT_DIR="${TEST_DIR}/etc"
-    MOCK_SYSUSERS_DIR="${TEST_DIR}/sysusers.d"
-    MOCK_DROPIN_DIR="${TEST_DIR}/dropin"
+    MOCK_ROOT_DIR="${TEST_DIR}"
+    MOCK_QM_ROOT_DIR="${MOCK_ROOT_DIR}/qm/rootfs"
+    MOCK_SYSUSERS_DIR="${MOCK_ROOT_DIR}/etc/sysusers.d"
+    MOCK_DROPIN_DIR="${TEST_DIR}/etc/containers/systemd/qm.container.d"
 
     mkdir -p "${MOCK_ROOT_DIR}"
+    mkdir -p "${MOCK_QM_ROOT_DIR}"
     mkdir -p "${MOCK_SYSUSERS_DIR}"
     mkdir -p "${MOCK_DROPIN_DIR}"
+
+    mkdir -p "${MOCK_SYSUSERS_DIR}"
+    mkdir -p "${MOCK_QM_ROOT_DIR}/etc"
 
     info_message "Test directory created at ${TEST_DIR}"
 }
@@ -61,8 +68,7 @@ trap cleanup_test_env EXIT
 #   $1 - Path to output file
 #######################################
 create_mock_passwd() {
-    local output_file="$1"
-    cat > "${output_file}" << 'EOF'
+    cat > "${MOCK_QM_ROOT_DIR}/etc/passwd" << 'EOF'
 root:x:0:0:root:/root:/bin/bash
 daemon:x:1:1:daemon:/usr/sbin:/usr/sbin/nologin
 bin:x:2:2:bin:/bin:/usr/sbin/nologin
@@ -79,8 +85,7 @@ EOF
 #   $1 - Path to output file
 #######################################
 create_mock_group() {
-    local output_file="$1"
-    cat > "${output_file}" << 'EOF'
+    cat > "${MOCK_QM_ROOT_DIR}/etc/group" << 'EOF'
 root:x:0:
 daemon:x:1:
 bin:x:2:
@@ -142,7 +147,7 @@ systemd-sysusers() {
 #   0 if valid, 1 if invalid
 #######################################
 verify_sysusers_format() {
-    local config_file="$1"
+    local config_file="${1}"
 
     if [ ! -f "${config_file}" ]; then
         fail_message "Config file ${config_file} does not exist"
@@ -201,21 +206,20 @@ record_test_result() {
 test_generate_sysusers_conf_basic() {
     info_message "TEST: generate_sysusers_conf - basic functionality"
 
-    # Setup
-    local passwd_file="${MOCK_ROOT_DIR}/passwd"
-    local group_file="${MOCK_ROOT_DIR}/group"
-    local output_file="${MOCK_SYSUSERS_DIR}/test-output.conf"
-
-    create_mock_passwd "${passwd_file}"
-    create_mock_group "${group_file}"
-
     # Source the userns script to get the function
     source "${USERNS_SCRIPT}"
+    # overwrite the userns root and qm root dir
+    local ROOT_DIR="${MOCK_ROOT_DIR}"
+    local QM_ROOT_DIR="${MOCK_QM_ROOT_DIR}"
+    create_mock_passwd
+    create_mock_group
 
     # Execute
-    generate_sysusers_conf "${MOCK_ROOT_DIR}" "${output_file}" 1000000000
+    generate_sysusers_conf 1000000000
 
     # Verify
+    local output_file="${MOCK_SYSUSERS_DIR}/${SYSUSERS_CONF}"
+
     local result=0
     if ! verify_sysusers_format "${output_file}"; then
         result=1
@@ -249,22 +253,20 @@ test_generate_sysusers_conf_basic() {
 test_generate_sysusers_conf_custom_offset() {
     info_message "TEST: generate_sysusers_conf - custom offset"
 
-    # Setup
-    local passwd_file="${MOCK_ROOT_DIR}/passwd"
-    local group_file="${MOCK_ROOT_DIR}/group"
-    local output_file="${MOCK_SYSUSERS_DIR}/test-offset.conf"
-
-    create_mock_passwd "${passwd_file}"
-    create_mock_group "${group_file}"
-
-    # Source the userns script
+    # Source the userns script to get the function
     source "${USERNS_SCRIPT}"
+    # overwrite the userns root and qm root dir
+    local ROOT_DIR="${MOCK_ROOT_DIR}"
+    local QM_ROOT_DIR="${MOCK_QM_ROOT_DIR}"
+    create_mock_passwd
+    create_mock_group
 
     # Execute with different offset
     local custom_offset=5000000000
-    generate_sysusers_conf "${MOCK_ROOT_DIR}" "${output_file}" "${custom_offset}"
+    generate_sysusers_conf "${custom_offset}"
 
     # Verify
+    local output_file="${MOCK_SYSUSERS_DIR}/${SYSUSERS_CONF}"
     local result=0
 
     # Check that root user has custom offset applied
@@ -290,21 +292,19 @@ test_generate_sysusers_conf_custom_offset() {
 test_generate_sysusers_conf_gecos() {
     info_message "TEST: generate_sysusers_conf - GECOS preservation"
 
-    # Setup
-    local passwd_file="${MOCK_ROOT_DIR}/passwd"
-    local group_file="${MOCK_ROOT_DIR}/group"
-    local output_file="${MOCK_SYSUSERS_DIR}/test-gecos.conf"
-
-    create_mock_passwd "${passwd_file}"
-    create_mock_group "${group_file}"
-
-    # Source the userns script
+    # Source the userns script to get the function
     source "${USERNS_SCRIPT}"
+    # overwrite the userns root and qm root dir
+    local ROOT_DIR="${MOCK_ROOT_DIR}"
+    local QM_ROOT_DIR="${MOCK_QM_ROOT_DIR}"
+    create_mock_passwd
+    create_mock_group
 
     # Execute
-    generate_sysusers_conf "${MOCK_ROOT_DIR}" "${output_file}" 1000000000
+    generate_sysusers_conf 1000000000
 
     # Verify
+    local output_file="${MOCK_SYSUSERS_DIR}/${SYSUSERS_CONF}"
     local result=0
 
     # Check that GECOS field is preserved with "QM - " prefix
@@ -328,17 +328,17 @@ test_generate_sysusers_conf_gecos() {
 test_generate_qm_dropin_basic() {
     info_message "TEST: generate_qm_dropin - basic functionality"
 
-    # Setup
-    local dropin_file="${MOCK_DROPIN_DIR}/test-dropin.conf"
-    local test_user="qm_root"
-
     # Source the userns script
     source "${USERNS_SCRIPT}"
+    local ROOT_DIR="${MOCK_ROOT_DIR}"
+    local QM_ROOT_DIR="${MOCK_QM_ROOT_DIR}"
+    local test_user="qm_root"
 
     # Execute
-    generate_qm_dropin "${dropin_file}" "${test_user}"
+    generate_qm_dropin "${test_user}"
 
     # Verify
+    local dropin_file="${MOCK_DROPIN_DIR}/${QM_CONF}"
     local result=0
 
     if [ ! -f "${dropin_file}" ]; then
@@ -366,17 +366,17 @@ test_generate_qm_dropin_basic() {
 test_generate_qm_dropin_custom_user() {
     info_message "TEST: generate_qm_dropin - custom username"
 
-    # Setup
-    local dropin_file="${MOCK_DROPIN_DIR}/test-dropin-custom.conf"
-    local test_user="custom_user_123"
-
     # Source the userns script
     source "${USERNS_SCRIPT}"
+    local ROOT_DIR="${MOCK_ROOT_DIR}"
+    local QM_ROOT_DIR="${MOCK_QM_ROOT_DIR}"
+    local test_user="qm_root"
 
     # Execute
-    generate_qm_dropin "${dropin_file}" "${test_user}"
+    generate_qm_dropin "${test_user}"
 
     # Verify
+    local dropin_file="${MOCK_DROPIN_DIR}/${QM_CONF}"
     local result=0
 
     if ! grep -q "^SubUIDMap=${test_user}$" "${dropin_file}"; then

--- a/userns
+++ b/userns
@@ -11,38 +11,49 @@ EOF
 )
 
 # Default values for user namespace settings
-ROOT_DIR="/etc"
+ROOT_DIR="/"
+QM_ROOT_DIR="/usr/lib/qm/rootfs/"
+
 ID_OFFSET=1000000000
 ID_RANGE=1500000000
-SYSUSERS_OUTPUT_DIR="/etc/sysusers.d"
+
+SYSUSERS_OUTPUT_DIR="/etc/sysusers.d/"
 SYSUSERS_CONF_FILE="qm-sysusers.conf"
 QM_DROPIN_DIR="/etc/containers/systemd/qm.container.d"
 QM_DROPIN_FILE="qm-user-namespaces.conf"
 
 
 function generate_sysusers_conf() {
-    local root_dir="${1}"
-    local outfile="${2}"
-    local id_offset=$3
+    local id_offset=$1
 
-    echo "# Type        Name        ID      GECOS       Home directory      Shell" > "${outfile}"
+    # shellcheck disable=SC2155
+    local qm_etc_passwd_file="$(realpath -m "${QM_ROOT_DIR}/etc/passwd")"
+    # shellcheck disable=SC2155
+    local qm_etc_group_file="$(realpath -m "${QM_ROOT_DIR}/etc/group")"
+    # shellcheck disable=SC2155
+    local sysusers_conf_file="$(realpath -m "${ROOT_DIR}/${SYSUSERS_OUTPUT_DIR}/${SYSUSERS_CONF_FILE}")"
+
+    echo "# Type        Name        ID      GECOS       Home directory      Shell" > "${sysusers_conf_file}"
     # shellcheck disable=SC2034
     while IFS=: read -r username password uid gid gecos home shell; do
         new_uid=$((id_offset+uid))
         new_gid=$((id_offset+gid))
         echo "u     qm_${username}      ${new_uid}:${new_gid}       \"QM - ${gecos}\""
-    done < "${root_dir}/passwd" >> "${outfile}"
+    done < "${qm_etc_passwd_file}" >> "${sysusers_conf_file}"
 
     # shellcheck disable=SC2034
     while IFS=: read -r group password gid members; do
         new_gid=$((id_offset+gid))
         echo "g     qm_${group}     ${new_gid}"
-    done < "${root_dir}/group" >> "${outfile}"
+    done < "${qm_etc_group_file}" >> "${sysusers_conf_file}"
+
+    echo "Created '${sysusers_conf_file}'"
 }
 
 function generate_qm_dropin() {
-    local file_path=$1
-    local user=$2
+    # shellcheck disable=SC2155
+    local file_path="$(realpath -m "${ROOT_DIR}/${QM_DROPIN_DIR}/${QM_DROPIN_FILE}")"
+    local user=$1
 
     cat > "${file_path}" <<EOF
 # Run the QM container in the user namespace qm using the map with name in the /etc/subgid file.
@@ -50,6 +61,8 @@ function generate_qm_dropin() {
 SubUIDMap=${user}
 SubGIDMap=${user}
 EOF
+
+    echo "Created '${file_path}'"
 }
 
 function add_subid_entries() {
@@ -58,11 +71,16 @@ function add_subid_entries() {
     local id_range_end=$((id_range_start+id_range))
     local user=$3
 
-    if ! grep -q "^${user}:" /etc/subuid 2>/dev/null; then
-        usermod --add-subuids "${id_range_start}-${id_range_end}" "${user}"
+    # shellcheck disable=SC2155
+    local etc_subuid_file="$(realpath -m "${ROOT_DIR}/etc/subuid")"
+    # shellcheck disable=SC2155
+    local etc_subgid_file="$(realpath -m "${ROOT_DIR}/etc/subgid")"
+
+    if ! grep -q "^${user}:" "${etc_subuid_file}" 2>/dev/null; then
+        usermod --root="${ROOT_DIR}" --add-subuids "${id_range_start}-${id_range_end}" "${user}"
     fi
-    if ! grep -q "^${user}:" /etc/subgid 2>/dev/null; then
-        usermod --add-subgids "${id_range_start}-${id_range_end}" "${user}"
+    if ! grep -q "^${user}:" "${etc_subgid_file}" 2>/dev/null; then
+        usermod --root="${ROOT_DIR}" --add-subgids "${id_range_start}-${id_range_end}" "${user}"
     fi
 }
 
@@ -75,8 +93,9 @@ Usage:
     $(basename "${0}") enable [options]
 
 Available options:
-    --root-dir      The root directory where passwd and group are located. Default: '${ROOT_DIR}'.
-    --sysusers-dir  Directory the '${SYSUSERS_CONF_FILE}' is being placed. Default: '${SYSUSERS_OUTPUT_DIR}'.
+    --root-dir      The root filesystem of the host. Default: '${ROOT_DIR}'.
+    --qm-root-dir   The root filesystem of QM. Default: '${QM_ROOT_DIR}'.
+    --sysusers-dir  Directory inside the ${ROOT_DIR} where the '${SYSUSERS_CONF_FILE}' is being placed. Default: '${SYSUSERS_OUTPUT_DIR}'.
     --id-offset     UID/GID offset to be applied. Default: '${ID_OFFSET}'.
     --id-range      Number of UIDs/GIDs reserved for the QM user namespace. Default: '${ID_RANGE}'.
 
@@ -89,6 +108,10 @@ EOF
         case $1 in
             --root-dir)
                 ROOT_DIR="${2}"
+                shift 2
+                ;;
+            --qm-root-dir)
+                QM_ROOT_DIR="${2}"
                 shift 2
                 ;;
             --sysusers-dir)
@@ -124,26 +147,28 @@ EOF
 
     # Generate sysusers configuration and trigger systemd-sysusers so that
     # users are created (required by adding subids)
-    local SYSUSERS_CONF_PATH="${SYSUSERS_OUTPUT_DIR}/${SYSUSERS_CONF_FILE}"
-    generate_sysusers_conf "${ROOT_DIR}" "${SYSUSERS_CONF_PATH}" "${ID_OFFSET}"
-    echo "Created '${SYSUSERS_CONF_PATH}'"
-    systemd-sysusers
+    generate_sysusers_conf "${ID_OFFSET}"
+    systemd-sysusers --root="${ROOT_DIR}"
 
     # Add subuids/subgids
     # A root user is always expected, so the corresponding qm user is qm_root
     add_subid_entries "${ID_OFFSET}" "${ID_RANGE}" "qm_root"
 
     # Add SubUIDMap= and SubGIDMap= to QM via drop-in
-    local QM_DROPIN_PATH="${QM_DROPIN_DIR}/${QM_DROPIN_FILE}"
-    generate_qm_dropin "${QM_DROPIN_PATH}" "qm_root"
-    echo "Created '${QM_DROPIN_PATH}'"
+    generate_qm_dropin "qm_root"
 }
 
 
 function remove_subid_entries() {
     local user=$1
-    sed -i "/^${user}:/d" /etc/subuid
-    sed -i "/^${user}:/d" /etc/subgid
+
+    # shellcheck disable=SC2155
+    local etc_subuid_file="$(realpath -m "${ROOT_DIR}/etc/subuid")"
+    # shellcheck disable=SC2155
+    local etc_subgid_file="$(realpath -m "${ROOT_DIR}/etc/subgid")"
+
+    sed -i "/^${user}:/d" "${etc_subuid_file}"
+    sed -i "/^${user}:/d" "${etc_subgid_file}"
 }
 
 
@@ -156,7 +181,9 @@ Usage:
     $(basename "${0}") disable [options]
 
 Available options:
-    --sysusers-dir  Directory the '${SYSUSERS_CONF_FILE}' is located. Default: '${SYSUSERS_OUTPUT_DIR}'.
+    --root-dir      The root filesystem of the host. Default: '${ROOT_DIR}'.
+    --qm-root-dir   The root filesystem of QM. Default: '${QM_ROOT_DIR}'.
+    --sysusers-dir  Directory inside the ${ROOT_DIR} where the '${SYSUSERS_CONF_FILE}' is located. Default: '${SYSUSERS_OUTPUT_DIR}'.
 
 Flags:
     -h, --help  Print help
@@ -165,6 +192,14 @@ EOF
 
     while [[ $# -gt 0 ]]; do
         case $1 in
+            --root-dir)
+                ROOT_DIR="${2}"
+                shift 2
+                ;;
+            --qm-root-dir)
+                QM_ROOT_DIR="${2}"
+                shift 2
+                ;;
             --sysusers-dir)
                 SYSUSERS_OUTPUT_DIR="${2}"
                 shift 2
@@ -189,8 +224,8 @@ EOF
     done
 
     remove_subid_entries "qm_root"
-    rm -f "${QM_DROPIN_DIR}/${QM_DROPIN_FILE}"
-    rm -f "${SYSUSERS_OUTPUT_DIR}/${SYSUSERS_CONF_FILE}"
+    rm -f "$(realpath -m "${ROOT_DIR}/${QM_DROPIN_DIR}/${QM_DROPIN_FILE}")"
+    rm -f "$(realpath -m "${ROOT_DIR}/${SYSUSERS_OUTPUT_DIR}/${SYSUSERS_CONF_FILE}")"
 }
 
 

--- a/userns
+++ b/userns
@@ -56,6 +56,7 @@ function generate_qm_dropin() {
     local user=$1
 
     cat > "${file_path}" <<EOF
+[Container]
 # Run the QM container in the user namespace qm using the map with name in the /etc/subgid file.
 # It also maps to the QM user created via systemd sysusers.
 SubUIDMap=${user}


### PR DESCRIPTION
This PR does
* Add missing `[Container` section to userns generated quadlet
*  userns to support --root-dir and --qm-root-dir and update unit tests

## Summary by Sourcery

Add root directory support to userns-generated configuration and update related tests.

New Features:
- Support separate root and QM root directories in userns-generated configuration files.

Enhancements:
- Adjust quadlet/userns configuration generation to align with new root directory layout.

Tests:
- Refactor userns unit tests to use the new root and QM root directory structure and validate updated output paths.